### PR TITLE
Make the acctest helper script a little easier to use

### DIFF
--- a/dns/acceptance.sh
+++ b/dns/acceptance.sh
@@ -7,30 +7,40 @@ set -x
 export DNS_DOMAIN_FORWARD="example.com."
 export DNS_DOMAIN_REVERSE="1.168.192.in-addr.arpa."
 
+DOCKER_CONTAINER_NAME=tf_acc_dns
+
+cleanup_docker() {
+	docker stop "$DOCKER_CONTAINER_NAME"
+	docker rm "$DOCKER_CONTAINER_NAME"
+}
+failed() {
+	cleanup_docker
+	exit 1
+}
+
 # Run with no authentication
 
 export DNS_UPDATE_SERVER=127.0.0.1
-docker run -d -p 53:53/udp \
+export DNS_UPDATE_PORT=55354
+docker run -d -p "$DNS_UPDATE_PORT:53/udp" \
 	-e BIND_DOMAIN_FORWARD=${DNS_DOMAIN_FORWARD} \
 	-e BIND_DOMAIN_REVERSE=${DNS_DOMAIN_REVERSE} \
 	-e BIND_INSECURE=true \
-	--name bind_insecure drebes/bind
-make testacc TEST=./dns
-docker stop bind_insecure
-docker rm bind_insecure
+	--name "$DOCKER_CONTAINER_NAME" drebes/bind || failed
+make testacc TEST=./dns || failed
+cleanup_docker
 
 # Run with authentication
 
 export DNS_UPDATE_KEYNAME=${DNS_DOMAIN_FORWARD}
 export DNS_UPDATE_KEYALGORITHM="hmac-md5"
 export DNS_UPDATE_KEYSECRET="c3VwZXJzZWNyZXQ="
-docker run -d -p 53:53/udp \
+docker run -d -p "$DNS_UPDATE_PORT:53/udp" \
 	-e BIND_DOMAIN_FORWARD=${DNS_DOMAIN_FORWARD} \
 	-e BIND_DOMAIN_REVERSE=${DNS_DOMAIN_REVERSE} \
 	-e BIND_KEY_NAME=${DNS_UPDATE_KEYNAME} \
 	-e BIND_KEY_ALGORITHM=${DNS_UPDATE_KEYALGORITHM} \
 	-e BIND_KEY_SECRET=${DNS_UPDATE_KEYSECRET} \
-	--name bind_secure drebes/bind
-make testacc TEST=./dns
-docker stop bind_secure
-docker rm bind_secure
+	--name "$DOCKER_CONTAINER_NAME" drebes/bind || failed
+make testacc TEST=./dns || failed
+cleanup_docker


### PR DESCRIPTION
The `dns/acceptance.sh` script starts up a bind server in docker to provide a target to run the acceptance tests against.

This is a couple minor adjustments to that script to make it easier to use:

- Run the local test DNS server on a non-standard port, to avoid conflicts with a real nameserver running on localhost:53

- Clean up the docker containers even if the tests fail, to avoid the need for manual cleanup in that case.

In order to implement this it was necessary to make the update port number configurable in the environment, similar to all of the other settings.