### PR TITLE
Compare all IP addresses consistently

### DIFF
--- a/dns/resource_dns_a_record_set.go
+++ b/dns/resource_dns_a_record_set.go
@@ -2,6 +2,7 @@ package dns
 
 import (
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
@@ -91,9 +92,25 @@ func resourceDnsARecordSetRead(d *schema.ResourceData, meta interface{}) error {
 			if err != nil {
 				return fmt.Errorf("Error querying DNS record: %s", err)
 			}
-			addresses.Add(addr)
+
+			// This ensures the IP address is formatted consistently
+			ip := net.ParseIP(addr)
+			if ip == nil {
+				return fmt.Errorf("Error parsing IP address: %s", addr)
+			}
+			addresses.Add(ip.String())
 		}
-		if !addresses.Equal(d.Get("addresses")) {
+
+		// This ensures the IP addresses are formatted consistently
+		expected := schema.NewSet(schema.HashString, nil)
+		for _, addr := range d.Get("addresses").(*schema.Set).List() {
+			ip := net.ParseIP(addr.(string))
+			if ip == nil {
+				return fmt.Errorf("Error parsing IP address: %s", addr)
+			}
+			expected.Add(ip.String())
+		}
+		if !addresses.Equal(expected) {
 			d.SetId("")
 			return fmt.Errorf("DNS record differs")
 		}

--- a/dns/resource_dns_a_record_set_test.go
+++ b/dns/resource_dns_a_record_set_test.go
@@ -120,7 +120,7 @@ var testAccDnsARecordSet_basic = fmt.Sprintf(`
   resource "dns_a_record_set" "foo" {
     zone = "example.com."
     name = "foo"
-    addresses = ["192.168.0.1", "192.168.0.2"]
+    addresses = ["192.168.000.001", "192.168.000.002"]
     ttl = 300
   }`)
 

--- a/dns/resource_dns_aaaa_record_set_test.go
+++ b/dns/resource_dns_aaaa_record_set_test.go
@@ -21,14 +21,14 @@ func TestAccDnsAAAARecordSet_basic(t *testing.T) {
 				Config: testAccDnsAAAARecordSet_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("dns_aaaa_record_set.bar", "addresses.#", "2"),
-					testAccCheckDnsAAAARecordSetExists(t, "dns_aaaa_record_set.bar", []interface{}{"fdd5:e282:43b8:5303:dead:beef:cafe:babe", "fdd5:e282:43b8:5303:cafe:babe:dead:beef"}),
+					testAccCheckDnsAAAARecordSetExists(t, "dns_aaaa_record_set.bar", []interface{}{"fdd5:e282::dead:beef:cafe:babe", "fdd5:e282::cafe:babe:dead:beef"}),
 				),
 			},
 			resource.TestStep{
 				Config: testAccDnsAAAARecordSet_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("dns_aaaa_record_set.bar", "addresses.#", "2"),
-					testAccCheckDnsAAAARecordSetExists(t, "dns_aaaa_record_set.bar", []interface{}{"fdd5:e282:43b8:5303:beef:dead:babe:cafe", "fdd5:e282:43b8:5303:babe:cafe:beef:dead"}),
+					testAccCheckDnsAAAARecordSetExists(t, "dns_aaaa_record_set.bar", []interface{}{"fdd5:e282::beef:dead:babe:cafe", "fdd5:e282::babe:cafe:beef:dead"}),
 				),
 			},
 		},
@@ -120,7 +120,7 @@ var testAccDnsAAAARecordSet_basic = fmt.Sprintf(`
   resource "dns_aaaa_record_set" "bar" {
     zone = "example.com."
     name = "bar"
-    addresses = ["fdd5:e282:43b8:5303:dead:beef:cafe:babe", "fdd5:e282:43b8:5303:cafe:babe:dead:beef"]
+    addresses = ["fdd5:e282:0000:0000:dead:beef:cafe:babe", "fdd5:e282:0000:0000:cafe:babe:dead:beef"]
     ttl = 300
   }`)
 
@@ -128,6 +128,6 @@ var testAccDnsAAAARecordSet_update = fmt.Sprintf(`
   resource "dns_aaaa_record_set" "bar" {
     zone = "example.com."
     name = "bar"
-    addresses = ["fdd5:e282:43b8:5303:beef:dead:babe:cafe", "fdd5:e282:43b8:5303:babe:cafe:beef:dead"]
+    addresses = ["fdd5:e282:0000:0000:beef:dead:babe:cafe", "fdd5:e282:0000:0000:babe:cafe:beef:dead"]
     ttl = 300
   }`)


### PR DESCRIPTION
This fixes #12 (and also #23). The problem is that the `digitalocean_droplet.ipv6_address` attribute returns an IPv6 address which does not use the `::` substitution, however the `dns_aaaa_record_set` resource when it reads the address back from DNS will get an address that uses the `::` substitution. This means that the addresses will always differ as we're comparing as strings even though the addresses are equivalent and so a `terraform apply` will always contain changes.

This fix works by feeding all IPv6 addresses through `net.ParseIP()` to create an IP object and then turns it back into a string again. The net result is all IPv6 addresses are now formatted consistently (using the `::` substitution as it happens) so the addresses will compare properly using string-based comparison.

Edit: #23 also showed that IPv4 addresses have the same problem if they are formatted such as `192.000.002.001`, although I think this would be a rarer occurrence in real-world use, however the same fix is applied when comparing IPv4 addresses.