### PR TITLE
Add expected record to fix TestAccDataDnsTxtRecordSet_Basic

### DIFF
--- a/dns/data_dns_txt_record_set_test.go
+++ b/dns/data_dns_txt_record_set_test.go
@@ -23,6 +23,7 @@ func TestAccDataDnsTxtRecordSet_Basic(t *testing.T) {
 			"foo",
 			[]string{
 				"google-site-verification=oqoe6Z7OB_726BNm33g4OdKK57KDtCfH266f8wAvLBo",
+				"google-site-verification=V8MoaHpn91Zfvk8uOTfdyxiKUGB38W083y9rZdqdlgI",
 				"v=spf1 include:_spf.google.com include:spf.mail.intercom.io  include:stspg-customer.com include:mail.zendesk.com ~all",
 				"status-page-domain-verification=dgtdvzlp8tfn",
 			},


### PR DESCRIPTION
Looks like the TXT records the test was depending on changed, resulting in [failing tests](https://travis-ci.org/terraform-providers/terraform-provider-dns/builds/291683469#L482)
```
go test -timeout=30s -parallel=4 github.com/terraform-providers/terraform-provider-dns github.com/terraform-providers/terraform-provider-dns/dns
? github.com/terraform-providers/terraform-provider-dns	[no test files]
--- FAIL: TestAccDataDnsTxtRecordSet_Basic (0.04s)
	testing.go:435: Step 0 error: Check failed: Check 1/1 error: Mismatch array count for records: got 4, wanted 3
FAIL
FAIL	github.com/terraform-providers/terraform-provider-dns/dns	0.051s
```

```
$ dig hashicorp.com TXT

[...]

;; QUESTION SECTION:
;hashicorp.com.			IN	TXT

;; ANSWER SECTION:
hashicorp.com.		300	IN	TXT	"google-site-verification=V8MoaHpn91Zfvk8uOTfdyxiKUGB38W083y9rZdqdlgI"
hashicorp.com.		300	IN	TXT	"v=spf1 include:_spf.google.com include:spf.mail.intercom.io  include:stspg-customer.com include:mail.zendesk.com ~all"
hashicorp.com.		300	IN	TXT	"google-site-verification=oqoe6Z7OB_726BNm33g4OdKK57KDtCfH266f8wAvLBo"
hashicorp.com.		300	IN	TXT	"status-page-domain-verification=dgtdvzlp8tfn"

[...]
```

This PR changes the records expected in `TestAccDataDnsTxtRecordSet_Basic` so they match match reality again. 