### PR TITLE
Switch to net.JoinHostPort()

### DIFF
--- a/dns/config.go
+++ b/dns/config.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"github.com/miekg/dns"
 	"log"
+	"net"
+	"strconv"
 )
 
 type Config struct {
@@ -27,7 +29,7 @@ func (c *Config) Client() (interface{}, error) {
 	log.Println("[INFO] Building DNSClient config structure")
 
 	var client DNSClient
-	client.srv_addr = fmt.Sprintf("%s:%d", c.server, c.port)
+	client.srv_addr = net.JoinHostPort(c.server, strconv.Itoa(c.port))
 	authCfgOk := false
 	if (c.keyname == "" && c.keysecret == "" && c.keyalgo == "") ||
 		(c.keyname != "" && c.keysecret != "" && c.keyalgo != "") {


### PR DESCRIPTION
Use `net.JoinHostPort()` instead of `net.Sprintf()` as it will correctly wrap
an IPv6 address with `[]`'s. Fixes #11.