### PR TITLE
data/dns_ptr_record_set: Implement data source for PTR

### DIFF
--- a/dns/data_dns_ptr_record_set.go
+++ b/dns/data_dns_ptr_record_set.go
@@ -1,0 +1,40 @@
+package dns
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceDnsPtrRecordSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDnsPtrRecordSetRead,
+		Schema: map[string]*schema.Schema{
+			"ip_address": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"ptr": &schema.Schema{
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDnsPtrRecordSetRead(d *schema.ResourceData, meta interface{}) error {
+	ipAddress := d.Get("ip_address").(string)
+	names, err := net.LookupAddr(ipAddress)
+	if err != nil {
+		return fmt.Errorf("error looking up PTR records for %q: %s", ipAddress, err)
+	}
+	if len(names) == 0 {
+		return fmt.Errorf("error looking up PTR records for %q: no records found", ipAddress)
+	}
+
+	d.Set("ptr", names[0])
+	d.SetId(ipAddress)
+
+	return nil
+}

--- a/dns/data_dns_ptr_record_set_test.go
+++ b/dns/data_dns_ptr_record_set_test.go
@@ -1,0 +1,45 @@
+package dns
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataDnsPtrRecordSet_Basic(t *testing.T) {
+	tests := []struct {
+		DataSourceBlock string
+		Expected        string
+		IPAddress       string
+	}{
+		{
+			`
+			data "dns_ptr_record_set" "foo" {
+			  ip_address = "8.8.8.8"
+			}
+			`,
+			"google-public-dns-a.google.com.",
+			"8.8.8.8",
+		},
+	}
+
+	for _, test := range tests {
+		resource.Test(t, resource.TestCase{
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				resource.TestStep{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("data.dns_ptr_record_set.foo", "ptr", test.Expected),
+					),
+				},
+				resource.TestStep{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr("data.dns_ptr_record_set.foo", "id", test.IPAddress),
+					),
+				},
+			},
+		})
+	}
+}

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -66,6 +66,7 @@ func Provider() terraform.ResourceProvider {
 			"dns_cname_record_set": dataSourceDnsCnameRecordSet(),
 			"dns_txt_record_set":   dataSourceDnsTxtRecordSet(),
 			"dns_ns_record_set":    dataSourceDnsNSRecordSet(),
+			"dns_ptr_record_set":   dataSourceDnsPtrRecordSet(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{

--- a/website/dns.erb
+++ b/website/dns.erb
@@ -23,9 +23,12 @@
                         <li<%= sidebar_current("docs-dns-datasource-cname-record-set") %>>
                             <a href="/docs/providers/dns/d/dns_cname_record_set.html">dns_cname_record_set</a>
                         </li>
-                      <li<%= sidebar_current("docs-dns-datasource-ns-record-set") %>>
-                        <a href="/docs/providers/dns/d/dns_ns_record_set.html">dns_ns_record_set</a>
-                      </li>
+                        <li<%= sidebar_current("docs-dns-datasource-ns-record-set") %>>
+                            <a href="/docs/providers/dns/d/dns_ns_record_set.html">dns_ns_record_set</a>
+                        </li>
+                        <li<%= sidebar_current("docs-dns-datasource-ptr-record-set") %>>
+                            <a href="/docs/providers/dns/d/dns_ptr_record_set.html">dns_ptr_record_set</a>
+                        </li>
                         <li<%= sidebar_current("docs-dns-datasource-txt-record-set") %>>
                             <a href="/docs/providers/dns/d/dns_txt_record_set.html">dns_txt_record_set</a>
                         </li>

--- a/website/docs/d/dns_ptr_record_set.html.markdown
+++ b/website/docs/d/dns_ptr_record_set.html.markdown
@@ -1,0 +1,39 @@
+---
+layout: "dns"
+page_title: "DNS: dns_ptr_record_set"
+sidebar_current: "docs-dns-datasource-ptr-record-set"
+description: |-
+  Get DNS PTR record set.
+---
+
+# dns_ptr_record_set
+
+Use this data source to get DNS PTR record set of the ip address.
+
+## Example Usage
+
+```hcl
+data "dns_ptr_record_set" "hashicorp" {
+  ip_address = "8.8.8.8"
+}
+
+output "hashi_ptr" {
+  value = "${data.dns_ptr_record_set.hashicorp.ptr}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+ * `ip_address` - (required): IP address to look up
+
+## Attributes Reference
+
+The following attributes are exported:
+
+ * `id` - Set to `ip_address`.
+
+ * `ptr` - A PTR record associated with `ip_address`.
+
+ __NOTE__: Only the first result is taken from the query.


### PR DESCRIPTION
Fix #31 

PTR data source giving users the ability to reverse lookup an ip address to obtain a DNS name. Passing acceptance test using google's public DNS server address (8.8.8.8)
```
=== RUN   TestAccDataDnsPtrRecordSet_Basic
--- PASS: TestAccDataDnsPtrRecordSet_Basic (0.04s)
```