### PR TITLE
Fix NXDOMAIN on read

### DIFF
--- a/dns/resource_dns_a_record_set.go
+++ b/dns/resource_dns_a_record_set.go
@@ -82,8 +82,14 @@ func resourceDnsARecordSetRead(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
-		if r.Rcode != dns.RcodeSuccess {
-			return fmt.Errorf("Error querying DNS record: %v", r.Rcode)
+		switch r.Rcode {
+		case dns.RcodeSuccess:
+			break
+		case dns.RcodeNameError:
+			d.SetId("")
+			return nil
+		default:
+			return fmt.Errorf("Error querying DNS record: %s", dns.RcodeToString[r.Rcode])
 		}
 
 		addresses := schema.NewSet(schema.HashString, nil)

--- a/dns/resource_dns_a_record_set_test.go
+++ b/dns/resource_dns_a_record_set_test.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -11,6 +12,37 @@ import (
 )
 
 func TestAccDnsARecordSet_Basic(t *testing.T) {
+
+	var rec_name, rec_zone string
+
+	deleteARecordSet := func() {
+		meta := testAccProvider.Meta()
+		c := meta.(*DNSClient).c
+		srv_addr := meta.(*DNSClient).srv_addr
+		keyname := meta.(*DNSClient).keyname
+		keyalgo := meta.(*DNSClient).keyalgo
+
+		msg := new(dns.Msg)
+
+		msg.SetUpdate(rec_zone)
+
+		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
+
+		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 A", rec_fqdn))
+		msg.RemoveRRset([]dns.RR{rr_remove})
+
+		if keyname != "" {
+			msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
+		}
+
+		r, _, err := c.Exchange(msg, srv_addr)
+		if err != nil {
+			t.Fatalf("Error deleting DNS record: %s", err)
+		}
+		if r.Rcode != dns.RcodeSuccess {
+			t.Fatalf("Error deleting DNS record: %v", r.Rcode)
+		}
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -21,14 +53,22 @@ func TestAccDnsARecordSet_Basic(t *testing.T) {
 				Config: testAccDnsARecordSet_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("dns_a_record_set.foo", "addresses.#", "2"),
-					testAccCheckDnsARecordSetExists(t, "dns_a_record_set.foo", []interface{}{"192.168.0.2", "192.168.0.1"}),
+					testAccCheckDnsARecordSetExists(t, "dns_a_record_set.foo", []interface{}{"192.168.0.2", "192.168.0.1"}, &rec_name, &rec_zone),
 				),
 			},
 			resource.TestStep{
 				Config: testAccDnsARecordSet_update,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("dns_a_record_set.foo", "addresses.#", "3"),
-					testAccCheckDnsARecordSetExists(t, "dns_a_record_set.foo", []interface{}{"10.0.0.3", "10.0.0.2", "10.0.0.1"}),
+					testAccCheckDnsARecordSetExists(t, "dns_a_record_set.foo", []interface{}{"10.0.0.3", "10.0.0.2", "10.0.0.1"}, &rec_name, &rec_zone),
+				),
+			},
+			resource.TestStep{
+				PreConfig: deleteARecordSet,
+				Config:    testAccDnsARecordSet_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("dns_a_record_set.foo", "addresses.#", "3"),
+					testAccCheckDnsARecordSetExists(t, "dns_a_record_set.foo", []interface{}{"10.0.0.3", "10.0.0.2", "10.0.0.1"}, &rec_name, &rec_zone),
 				),
 			},
 		},
@@ -67,7 +107,7 @@ func testAccCheckDnsARecordSetDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckDnsARecordSetExists(t *testing.T, n string, addr []interface{}) resource.TestCheckFunc {
+func testAccCheckDnsARecordSetExists(t *testing.T, n string, addr []interface{}, rec_name, rec_zone *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -77,14 +117,14 @@ func testAccCheckDnsARecordSetExists(t *testing.T, n string, addr []interface{})
 			return fmt.Errorf("No ID is set")
 		}
 
-		rec_name := rs.Primary.Attributes["name"]
-		rec_zone := rs.Primary.Attributes["zone"]
+		*rec_name = rs.Primary.Attributes["name"]
+		*rec_zone = rs.Primary.Attributes["zone"]
 
-		if rec_zone != dns.Fqdn(rec_zone) {
+		if *rec_zone != dns.Fqdn(*rec_zone) {
 			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
 		}
 
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
+		rec_fqdn := fmt.Sprintf("%s.%s", *rec_name, *rec_zone)
 
 		meta := testAccProvider.Meta()
 		c := meta.(*DNSClient).c

--- a/dns/resource_dns_aaaa_record_set.go
+++ b/dns/resource_dns_aaaa_record_set.go
@@ -82,8 +82,14 @@ func resourceDnsAAAARecordSetRead(d *schema.ResourceData, meta interface{}) erro
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
-		if r.Rcode != dns.RcodeSuccess {
-			return fmt.Errorf("Error querying DNS record: %v", r.Rcode)
+		switch r.Rcode {
+		case dns.RcodeSuccess:
+			break
+		case dns.RcodeNameError:
+			d.SetId("")
+			return nil
+		default:
+			return fmt.Errorf("Error querying DNS record: %s", dns.RcodeToString[r.Rcode])
 		}
 
 		addresses := schema.NewSet(schema.HashString, nil)

--- a/dns/resource_dns_cname_record.go
+++ b/dns/resource_dns_cname_record.go
@@ -89,8 +89,14 @@ func resourceDnsCnameRecordRead(d *schema.ResourceData, meta interface{}) error 
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
-		if r.Rcode != dns.RcodeSuccess {
-			return fmt.Errorf("Error querying DNS record: %v", r.Rcode)
+		switch r.Rcode {
+		case dns.RcodeSuccess:
+			break
+		case dns.RcodeNameError:
+			d.SetId("")
+			return nil
+		default:
+			return fmt.Errorf("Error querying DNS record: %s", dns.RcodeToString[r.Rcode])
 		}
 
 		if len(r.Answer) > 1 {

--- a/dns/resource_dns_cname_record_test.go
+++ b/dns/resource_dns_cname_record_test.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -10,6 +11,37 @@ import (
 )
 
 func TestAccDnsCnameRecord_basic(t *testing.T) {
+
+	var rec_name, rec_zone string
+
+	deleteCnameRecord := func() {
+		meta := testAccProvider.Meta()
+		c := meta.(*DNSClient).c
+		srv_addr := meta.(*DNSClient).srv_addr
+		keyname := meta.(*DNSClient).keyname
+		keyalgo := meta.(*DNSClient).keyalgo
+
+		msg := new(dns.Msg)
+
+		msg.SetUpdate(rec_zone)
+
+		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
+
+		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 CNAME", rec_fqdn))
+		msg.RemoveRRset([]dns.RR{rr_remove})
+
+		if keyname != "" {
+			msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
+		}
+
+		r, _, err := c.Exchange(msg, srv_addr)
+		if err != nil {
+			t.Fatalf("Error deleting DNS record: %s", err)
+		}
+		if r.Rcode != dns.RcodeSuccess {
+			t.Fatalf("Error deleting DNS record: %v", r.Rcode)
+		}
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -19,13 +51,20 @@ func TestAccDnsCnameRecord_basic(t *testing.T) {
 			resource.TestStep{
 				Config: testAccDnsCnameRecord_basic,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDnsCnameRecordExists(t, "dns_cname_record.foo", "bar.example.com."),
+					testAccCheckDnsCnameRecordExists(t, "dns_cname_record.foo", "bar.example.com.", &rec_name, &rec_zone),
 				),
 			},
 			resource.TestStep{
 				Config: testAccDnsCnameRecord_update,
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckDnsCnameRecordExists(t, "dns_cname_record.foo", "baz.example.com."),
+					testAccCheckDnsCnameRecordExists(t, "dns_cname_record.foo", "baz.example.com.", &rec_name, &rec_zone),
+				),
+			},
+			resource.TestStep{
+				PreConfig: deleteCnameRecord,
+				Config:    testAccDnsCnameRecord_update,
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckDnsCnameRecordExists(t, "dns_cname_record.foo", "baz.example.com.", &rec_name, &rec_zone),
 				),
 			},
 		},
@@ -64,7 +103,7 @@ func testAccCheckDnsCnameRecordDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckDnsCnameRecordExists(t *testing.T, n string, expected string) resource.TestCheckFunc {
+func testAccCheckDnsCnameRecordExists(t *testing.T, n string, expected string, rec_name, rec_zone *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -74,14 +113,14 @@ func testAccCheckDnsCnameRecordExists(t *testing.T, n string, expected string) r
 			return fmt.Errorf("No ID is set")
 		}
 
-		rec_name := rs.Primary.Attributes["name"]
-		rec_zone := rs.Primary.Attributes["zone"]
+		*rec_name = rs.Primary.Attributes["name"]
+		*rec_zone = rs.Primary.Attributes["zone"]
 
-		if rec_zone != dns.Fqdn(rec_zone) {
+		if *rec_zone != dns.Fqdn(*rec_zone) {
 			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
 		}
 
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
+		rec_fqdn := fmt.Sprintf("%s.%s", *rec_name, *rec_zone)
 
 		meta := testAccProvider.Meta()
 		c := meta.(*DNSClient).c

--- a/dns/resource_dns_ns_record_set.go
+++ b/dns/resource_dns_ns_record_set.go
@@ -83,7 +83,13 @@ func resourceDnsNSRecordSetRead(d *schema.ResourceData, meta interface{}) error 
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
-		if r.Rcode != dns.RcodeSuccess {
+		switch r.Rcode {
+		case dns.RcodeSuccess:
+			break
+		case dns.RcodeNameError:
+			d.SetId("")
+			return nil
+		default:
 			return fmt.Errorf("Error querying DNS record: %s", dns.RcodeToString[r.Rcode])
 		}
 

--- a/dns/resource_dns_ns_record_set_test.go
+++ b/dns/resource_dns_ns_record_set_test.go
@@ -2,14 +2,47 @@ package dns
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
 	"github.com/miekg/dns"
-	"testing"
 )
 
 func TestAccDnsNSRecordSet_Basic(t *testing.T) {
+
+	var rec_name, rec_zone string
+
+	deleteNSRecordSet := func() {
+		meta := testAccProvider.Meta()
+		c := meta.(*DNSClient).c
+		srv_addr := meta.(*DNSClient).srv_addr
+		keyname := meta.(*DNSClient).keyname
+		keyalgo := meta.(*DNSClient).keyalgo
+
+		msg := new(dns.Msg)
+
+		msg.SetUpdate(rec_zone)
+
+		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
+
+		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 NS", rec_fqdn))
+		msg.RemoveRRset([]dns.RR{rr_remove})
+
+		if keyname != "" {
+			msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
+		}
+
+		r, _, err := c.Exchange(msg, srv_addr)
+		if err != nil {
+			t.Fatalf("Error deleting DNS record: %s", err)
+		}
+		if r.Rcode != dns.RcodeSuccess {
+			t.Fatalf("Error deleting DNS record: %v", r.Rcode)
+		}
+	}
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -20,14 +53,22 @@ func TestAccDnsNSRecordSet_Basic(t *testing.T) {
 				Config: testAccDnsNSRecordSet_basic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("dns_ns_record_set.foo", "nameservers.#", "2"),
-					testAccCheckDnsNSRecordSetExists(t, "dns_ns_record_set.foo", []interface{}{"ns1.testdns.co.uk.", "ns2.testdns.co.uk."}),
+					testAccCheckDnsNSRecordSetExists(t, "dns_ns_record_set.foo", []interface{}{"ns1.testdns.co.uk.", "ns2.testdns.co.uk."}, &rec_name, &rec_zone),
 				),
 			},
 			resource.TestStep{
 				Config: testAccDnsNSRecordSet_update,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("dns_ns_record_set.bar", "nameservers.#", "3"),
-					testAccCheckDnsNSRecordSetExists(t, "dns_ns_record_set.bar", []interface{}{"ns1.test2dns.co.uk.", "ns2.test2dns.co.uk.", "ns3.test2dns.co.uk."}),
+					resource.TestCheckResourceAttr("dns_ns_record_set.foo", "nameservers.#", "3"),
+					testAccCheckDnsNSRecordSetExists(t, "dns_ns_record_set.foo", []interface{}{"ns1.test2dns.co.uk.", "ns2.test2dns.co.uk.", "ns3.test2dns.co.uk."}, &rec_name, &rec_zone),
+				),
+			},
+			resource.TestStep{
+				PreConfig: deleteNSRecordSet,
+				Config:    testAccDnsNSRecordSet_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("dns_ns_record_set.foo", "nameservers.#", "3"),
+					testAccCheckDnsNSRecordSetExists(t, "dns_ns_record_set.foo", []interface{}{"ns1.test2dns.co.uk.", "ns2.test2dns.co.uk.", "ns3.test2dns.co.uk."}, &rec_name, &rec_zone),
 				),
 			},
 		},
@@ -67,7 +108,7 @@ func testAccCheckDnsNSRecordSetDestroy(s *terraform.State) error {
 	return nil
 }
 
-func testAccCheckDnsNSRecordSetExists(t *testing.T, n string, nameserver []interface{}) resource.TestCheckFunc {
+func testAccCheckDnsNSRecordSetExists(t *testing.T, n string, nameserver []interface{}, rec_name, rec_zone *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[n]
 		if !ok {
@@ -77,13 +118,14 @@ func testAccCheckDnsNSRecordSetExists(t *testing.T, n string, nameserver []inter
 			return fmt.Errorf("No ID is set")
 		}
 
-		rec_name := rs.Primary.Attributes["name"]
-		rec_zone := rs.Primary.Attributes["zone"]
-		if rec_zone != dns.Fqdn(rec_zone) {
+		*rec_name = rs.Primary.Attributes["name"]
+		*rec_zone = rs.Primary.Attributes["zone"]
+
+		if *rec_zone != dns.Fqdn(*rec_zone) {
 			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
 		}
 
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
+		rec_fqdn := fmt.Sprintf("%s.%s", *rec_name, *rec_zone)
 
 		meta := testAccProvider.Meta()
 		c := meta.(*DNSClient).c
@@ -130,9 +172,9 @@ var testAccDnsNSRecordSet_basic = fmt.Sprintf(`
   }`)
 
 var testAccDnsNSRecordSet_update = fmt.Sprintf(`
-  resource "dns_ns_record_set" "bar" {
+  resource "dns_ns_record_set" "foo" {
     zone = "example.com."
-    name = "bar"
+    name = "foo"
     nameservers = ["ns1.test2dns.co.uk.", "ns2.test2dns.co.uk.", "ns3.test2dns.co.uk.",]
     ttl = 60
   }`)

--- a/dns/resource_dns_ptr_record.go
+++ b/dns/resource_dns_ptr_record.go
@@ -89,8 +89,14 @@ func resourceDnsPtrRecordRead(d *schema.ResourceData, meta interface{}) error {
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
-		if r.Rcode != dns.RcodeSuccess {
-			return fmt.Errorf("Error querying DNS record: %v", r.Rcode)
+		switch r.Rcode {
+		case dns.RcodeSuccess:
+			break
+		case dns.RcodeNameError:
+			d.SetId("")
+			return nil
+		default:
+			return fmt.Errorf("Error querying DNS record: %s", dns.RcodeToString[r.Rcode])
 		}
 
 		if len(r.Answer) > 1 {


### PR DESCRIPTION
This fixes #2.

With tests updated:
```
$ make testacc TEST=./dns TESTARGS='-run=TestAccDns*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./dns -v -run=TestAccDns* -timeout 120m
=== RUN   TestAccDnsARecordSet_Basic
--- FAIL: TestAccDnsARecordSet_Basic (0.05s)
	testing.go:434: Step 2 error: Error refreshing: 1 error(s) occurred:
		
		* dns_a_record_set.foo: 1 error(s) occurred:
		
		* dns_a_record_set.foo: dns_a_record_set.foo: Error querying DNS record: 3
=== RUN   TestAccDnsAAAARecordSet_basic
--- FAIL: TestAccDnsAAAARecordSet_basic (0.04s)
	testing.go:434: Step 2 error: Error refreshing: 1 error(s) occurred:
		
		* dns_aaaa_record_set.bar: 1 error(s) occurred:
		
		* dns_aaaa_record_set.bar: dns_aaaa_record_set.bar: Error querying DNS record: 3
=== RUN   TestAccDnsCnameRecord_basic
--- FAIL: TestAccDnsCnameRecord_basic (0.04s)
	testing.go:434: Step 2 error: Error refreshing: 1 error(s) occurred:
		
		* dns_cname_record.foo: 1 error(s) occurred:
		
		* dns_cname_record.foo: dns_cname_record.foo: Error querying DNS record: 3
=== RUN   TestAccDnsNSRecordSet_Basic
--- FAIL: TestAccDnsNSRecordSet_Basic (0.04s)
	testing.go:434: Step 2 error: Error refreshing: 1 error(s) occurred:
		
		* dns_ns_record_set.foo: 1 error(s) occurred:
		
		* dns_ns_record_set.foo: dns_ns_record_set.foo: Error querying DNS record: NXDOMAIN
=== RUN   TestAccDnsPtrRecord_basic
--- FAIL: TestAccDnsPtrRecord_basic (0.04s)
	testing.go:434: Step 2 error: Error refreshing: 1 error(s) occurred:
		
		* dns_ptr_record.foo: 1 error(s) occurred:
		
		* dns_ptr_record.foo: dns_ptr_record.foo: Error querying DNS record: 3
FAIL
exit status 1
FAIL	github.com/terraform-providers/terraform-provider-dns/dns	0.216s
make: *** [testacc] Error 1
```
And with the code fixed:
```
$ make testacc TEST=./dns TESTARGS='-run=TestAccDns*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./dns -v -run=TestAccDns* -timeout 120m
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (0.20s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (0.06s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (0.06s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (0.06s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (0.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-dns/dns	0.462s
```