### PR TITLE
TSIG on reads and handle UDP truncation

### DIFF
--- a/dns/resource_dns_a_record_set.go
+++ b/dns/resource_dns_a_record_set.go
@@ -3,7 +3,6 @@ package dns
 import (
 	"fmt"
 	"net"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/miekg/dns"
@@ -72,13 +71,10 @@ func resourceDnsARecordSetRead(d *schema.ResourceData, meta interface{}) error {
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypeA)
 
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, true, meta)
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
@@ -140,11 +136,6 @@ func resourceDnsARecordSetUpdate(d *schema.ResourceData, meta interface{}) error
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-		keyname := meta.(*DNSClient).keyname
-		keyalgo := meta.(*DNSClient).keyalgo
-
 		msg := new(dns.Msg)
 
 		msg.SetUpdate(rec_zone)
@@ -167,11 +158,7 @@ func resourceDnsARecordSetUpdate(d *schema.ResourceData, meta interface{}) error
 				msg.Insert([]dns.RR{rr_insert})
 			}
 
-			if keyname != "" {
-				msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
-			}
-
-			r, _, err := c.Exchange(msg, srv_addr)
+			r, err := exchange(msg, true, meta)
 			if err != nil {
 				d.SetId("")
 				return fmt.Errorf("Error updating DNS record: %s", err)
@@ -204,11 +191,6 @@ func resourceDnsARecordSetDelete(d *schema.ResourceData, meta interface{}) error
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-		keyname := meta.(*DNSClient).keyname
-		keyalgo := meta.(*DNSClient).keyalgo
-
 		msg := new(dns.Msg)
 
 		msg.SetUpdate(rec_zone)
@@ -216,11 +198,7 @@ func resourceDnsARecordSetDelete(d *schema.ResourceData, meta interface{}) error
 		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 A", rec_fqdn))
 		msg.RemoveRRset([]dns.RR{rr_remove})
 
-		if keyname != "" {
-			msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
-		}
-
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, true, meta)
 		if err != nil {
 			return fmt.Errorf("Error deleting DNS record: %s", err)
 		}

--- a/dns/resource_dns_a_record_set_test.go
+++ b/dns/resource_dns_a_record_set_test.go
@@ -3,7 +3,6 @@ package dns
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -17,10 +16,6 @@ func TestAccDnsARecordSet_Basic(t *testing.T) {
 
 	deleteARecordSet := func() {
 		meta := testAccProvider.Meta()
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-		keyname := meta.(*DNSClient).keyname
-		keyalgo := meta.(*DNSClient).keyalgo
 
 		msg := new(dns.Msg)
 
@@ -31,11 +26,7 @@ func TestAccDnsARecordSet_Basic(t *testing.T) {
 		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 A", rec_fqdn))
 		msg.RemoveRRset([]dns.RR{rr_remove})
 
-		if keyname != "" {
-			msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
-		}
-
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, true, meta)
 		if err != nil {
 			t.Fatalf("Error deleting DNS record: %s", err)
 		}
@@ -77,8 +68,6 @@ func TestAccDnsARecordSet_Basic(t *testing.T) {
 
 func testAccCheckDnsARecordSetDestroy(s *terraform.State) error {
 	meta := testAccProvider.Meta()
-	c := meta.(*DNSClient).c
-	srv_addr := meta.(*DNSClient).srv_addr
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "dns_a_record_set" {
 			continue
@@ -95,7 +84,7 @@ func testAccCheckDnsARecordSetDestroy(s *terraform.State) error {
 
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypeA)
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, false, meta)
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
@@ -127,12 +116,10 @@ func testAccCheckDnsARecordSetExists(t *testing.T, n string, addr []interface{},
 		rec_fqdn := fmt.Sprintf("%s.%s", *rec_name, *rec_zone)
 
 		meta := testAccProvider.Meta()
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
 
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypeA)
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, false, meta)
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}

--- a/dns/resource_dns_aaaa_record_set.go
+++ b/dns/resource_dns_aaaa_record_set.go
@@ -3,7 +3,6 @@ package dns
 import (
 	"fmt"
 	"net"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/miekg/dns"
@@ -72,13 +71,10 @@ func resourceDnsAAAARecordSetRead(d *schema.ResourceData, meta interface{}) erro
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypeAAAA)
 
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, true, meta)
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
@@ -140,11 +136,6 @@ func resourceDnsAAAARecordSetUpdate(d *schema.ResourceData, meta interface{}) er
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-		keyname := meta.(*DNSClient).keyname
-		keyalgo := meta.(*DNSClient).keyalgo
-
 		msg := new(dns.Msg)
 
 		msg.SetUpdate(rec_zone)
@@ -167,11 +158,7 @@ func resourceDnsAAAARecordSetUpdate(d *schema.ResourceData, meta interface{}) er
 				msg.Insert([]dns.RR{rr_insert})
 			}
 
-			if keyname != "" {
-				msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
-			}
-
-			r, _, err := c.Exchange(msg, srv_addr)
+			r, err := exchange(msg, true, meta)
 			if err != nil {
 				d.SetId("")
 				return fmt.Errorf("Error updating DNS record: %s", err)
@@ -204,11 +191,6 @@ func resourceDnsAAAARecordSetDelete(d *schema.ResourceData, meta interface{}) er
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-		keyname := meta.(*DNSClient).keyname
-		keyalgo := meta.(*DNSClient).keyalgo
-
 		msg := new(dns.Msg)
 
 		msg.SetUpdate(rec_zone)
@@ -216,11 +198,7 @@ func resourceDnsAAAARecordSetDelete(d *schema.ResourceData, meta interface{}) er
 		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 AAAA", rec_fqdn))
 		msg.RemoveRRset([]dns.RR{rr_remove})
 
-		if keyname != "" {
-			msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
-		}
-
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, true, meta)
 		if err != nil {
 			return fmt.Errorf("Error deleting DNS record: %s", err)
 		}

--- a/dns/resource_dns_aaaa_record_set_test.go
+++ b/dns/resource_dns_aaaa_record_set_test.go
@@ -71,6 +71,13 @@ func TestAccDnsAAAARecordSet_basic(t *testing.T) {
 					testAccCheckDnsAAAARecordSetExists(t, "dns_aaaa_record_set.bar", []interface{}{"fdd5:e282::beef:dead:babe:cafe", "fdd5:e282::babe:cafe:beef:dead"}, &rec_name, &rec_zone),
 				),
 			},
+			resource.TestStep{
+				Config: testAccDnsAAAARecordSet_retry,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("dns_aaaa_record_set.bar", "addresses.#", "14"),
+					testAccCheckDnsAAAARecordSetExists(t, "dns_aaaa_record_set.bar", []interface{}{"fdd5:e282::beef:dead:babe:cafe", "fdd5:e282::babe:cafe:beef:dead", "fdd5:e282::beef:babe:dead:cafe", "fdd5:e282::babe:beef:cafe:dead", "fdd5:e282::cafe:beef:babe:dead", "fdd5:e282::cafe:beef:dead:babe", "fdd5:e282::cafe:babe:dead:beef", "fdd5:e282::cafe:babe:beef:dead", "fdd5:e282::dead:babe:cafe:beef", "fdd5:e282::dead:babe:beef:cafe", "fdd5:e282::dead:cafe:babe:beef", "fdd5:e282::dead:cafe:beef:babe", "fdd5:e282::dead:beef:cafe:babe", "fdd5:e282::dead:beef:babe:cafe"}, &rec_name, &rec_zone),
+				),
+			},
 		},
 	})
 }
@@ -169,5 +176,13 @@ var testAccDnsAAAARecordSet_update = fmt.Sprintf(`
     zone = "example.com."
     name = "bar"
     addresses = ["fdd5:e282:0000:0000:beef:dead:babe:cafe", "fdd5:e282:0000:0000:babe:cafe:beef:dead"]
+    ttl = 300
+  }`)
+
+var testAccDnsAAAARecordSet_retry = fmt.Sprintf(`
+  resource "dns_aaaa_record_set" "bar" {
+    zone = "example.com."
+    name = "bar"
+    addresses = ["fdd5:e282::beef:dead:babe:cafe", "fdd5:e282::babe:cafe:beef:dead", "fdd5:e282::beef:babe:dead:cafe", "fdd5:e282::babe:beef:cafe:dead", "fdd5:e282::cafe:beef:babe:dead", "fdd5:e282::cafe:beef:dead:babe", "fdd5:e282::cafe:babe:dead:beef", "fdd5:e282::cafe:babe:beef:dead", "fdd5:e282::dead:babe:cafe:beef", "fdd5:e282::dead:babe:beef:cafe", "fdd5:e282::dead:cafe:babe:beef", "fdd5:e282::dead:cafe:beef:babe", "fdd5:e282::dead:beef:cafe:babe", "fdd5:e282::dead:beef:babe:cafe"]
     ttl = 300
   }`)

--- a/dns/resource_dns_cname_record.go
+++ b/dns/resource_dns_cname_record.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/miekg/dns"
@@ -79,13 +78,10 @@ func resourceDnsCnameRecordRead(d *schema.ResourceData, meta interface{}) error 
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypeCNAME)
 
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, true, meta)
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
@@ -136,11 +132,6 @@ func resourceDnsCnameRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-		keyname := meta.(*DNSClient).keyname
-		keyalgo := meta.(*DNSClient).keyalgo
-
 		msg := new(dns.Msg)
 
 		msg.SetUpdate(rec_zone)
@@ -157,11 +148,7 @@ func resourceDnsCnameRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 				msg.Insert([]dns.RR{rr_insert})
 			}
 
-			if keyname != "" {
-				msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
-			}
-
-			r, _, err := c.Exchange(msg, srv_addr)
+			r, err := exchange(msg, true, meta)
 			if err != nil {
 				d.SetId("")
 				return fmt.Errorf("Error updating DNS record: %s", err)
@@ -194,11 +181,6 @@ func resourceDnsCnameRecordDelete(d *schema.ResourceData, meta interface{}) erro
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-		keyname := meta.(*DNSClient).keyname
-		keyalgo := meta.(*DNSClient).keyalgo
-
 		msg := new(dns.Msg)
 
 		msg.SetUpdate(rec_zone)
@@ -206,11 +188,7 @@ func resourceDnsCnameRecordDelete(d *schema.ResourceData, meta interface{}) erro
 		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 CNAME", rec_fqdn))
 		msg.RemoveRRset([]dns.RR{rr_remove})
 
-		if keyname != "" {
-			msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
-		}
-
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, true, meta)
 		if err != nil {
 			return fmt.Errorf("Error deleting DNS record: %s", err)
 		}

--- a/dns/resource_dns_cname_record_test.go
+++ b/dns/resource_dns_cname_record_test.go
@@ -3,7 +3,6 @@ package dns
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -16,10 +15,6 @@ func TestAccDnsCnameRecord_basic(t *testing.T) {
 
 	deleteCnameRecord := func() {
 		meta := testAccProvider.Meta()
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-		keyname := meta.(*DNSClient).keyname
-		keyalgo := meta.(*DNSClient).keyalgo
 
 		msg := new(dns.Msg)
 
@@ -30,11 +25,7 @@ func TestAccDnsCnameRecord_basic(t *testing.T) {
 		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 CNAME", rec_fqdn))
 		msg.RemoveRRset([]dns.RR{rr_remove})
 
-		if keyname != "" {
-			msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
-		}
-
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, true, meta)
 		if err != nil {
 			t.Fatalf("Error deleting DNS record: %s", err)
 		}
@@ -73,8 +64,6 @@ func TestAccDnsCnameRecord_basic(t *testing.T) {
 
 func testAccCheckDnsCnameRecordDestroy(s *terraform.State) error {
 	meta := testAccProvider.Meta()
-	c := meta.(*DNSClient).c
-	srv_addr := meta.(*DNSClient).srv_addr
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "dns_cname_record" {
 			continue
@@ -91,7 +80,7 @@ func testAccCheckDnsCnameRecordDestroy(s *terraform.State) error {
 
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypeCNAME)
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, false, meta)
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
@@ -123,12 +112,10 @@ func testAccCheckDnsCnameRecordExists(t *testing.T, n string, expected string, r
 		rec_fqdn := fmt.Sprintf("%s.%s", *rec_name, *rec_zone)
 
 		meta := testAccProvider.Meta()
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
 
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypeCNAME)
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, false, meta)
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}

--- a/dns/resource_dns_ptr_record.go
+++ b/dns/resource_dns_ptr_record.go
@@ -2,7 +2,6 @@ package dns
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/miekg/dns"
@@ -79,13 +78,10 @@ func resourceDnsPtrRecordRead(d *schema.ResourceData, meta interface{}) error {
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypePTR)
 
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, true, meta)
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
@@ -136,11 +132,6 @@ func resourceDnsPtrRecordUpdate(d *schema.ResourceData, meta interface{}) error 
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-		keyname := meta.(*DNSClient).keyname
-		keyalgo := meta.(*DNSClient).keyalgo
-
 		msg := new(dns.Msg)
 
 		msg.SetUpdate(rec_zone)
@@ -157,11 +148,7 @@ func resourceDnsPtrRecordUpdate(d *schema.ResourceData, meta interface{}) error 
 				msg.Insert([]dns.RR{rr_insert})
 			}
 
-			if keyname != "" {
-				msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
-			}
-
-			r, _, err := c.Exchange(msg, srv_addr)
+			r, err := exchange(msg, true, meta)
 			if err != nil {
 				d.SetId("")
 				return fmt.Errorf("Error updating DNS record: %s", err)
@@ -194,11 +181,6 @@ func resourceDnsPtrRecordDelete(d *schema.ResourceData, meta interface{}) error 
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-		keyname := meta.(*DNSClient).keyname
-		keyalgo := meta.(*DNSClient).keyalgo
-
 		msg := new(dns.Msg)
 
 		msg.SetUpdate(rec_zone)
@@ -206,11 +188,7 @@ func resourceDnsPtrRecordDelete(d *schema.ResourceData, meta interface{}) error 
 		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 PTR", rec_fqdn))
 		msg.RemoveRRset([]dns.RR{rr_remove})
 
-		if keyname != "" {
-			msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
-		}
-
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, true, meta)
 		if err != nil {
 			return fmt.Errorf("Error deleting DNS record: %s", err)
 		}

--- a/dns/resource_dns_ptr_record_test.go
+++ b/dns/resource_dns_ptr_record_test.go
@@ -3,7 +3,6 @@ package dns
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
@@ -16,10 +15,6 @@ func TestAccDnsPtrRecord_basic(t *testing.T) {
 
 	deletePtrRecord := func() {
 		meta := testAccProvider.Meta()
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
-		keyname := meta.(*DNSClient).keyname
-		keyalgo := meta.(*DNSClient).keyalgo
 
 		msg := new(dns.Msg)
 
@@ -30,11 +25,7 @@ func TestAccDnsPtrRecord_basic(t *testing.T) {
 		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 PTR", rec_fqdn))
 		msg.RemoveRRset([]dns.RR{rr_remove})
 
-		if keyname != "" {
-			msg.SetTsig(keyname, keyalgo, 300, time.Now().Unix())
-		}
-
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, true, meta)
 		if err != nil {
 			t.Fatalf("Error deleting DNS record: %s", err)
 		}
@@ -73,8 +64,6 @@ func TestAccDnsPtrRecord_basic(t *testing.T) {
 
 func testAccCheckDnsPtrRecordDestroy(s *terraform.State) error {
 	meta := testAccProvider.Meta()
-	c := meta.(*DNSClient).c
-	srv_addr := meta.(*DNSClient).srv_addr
 	for _, rs := range s.RootModule().Resources {
 		if rs.Type != "dns_ptr_record" {
 			continue
@@ -91,7 +80,7 @@ func testAccCheckDnsPtrRecordDestroy(s *terraform.State) error {
 
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypePTR)
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, false, meta)
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
@@ -123,12 +112,10 @@ func testAccCheckDnsPtrRecordExists(t *testing.T, n string, expected string, rec
 		rec_fqdn := fmt.Sprintf("%s.%s", *rec_name, *rec_zone)
 
 		meta := testAccProvider.Meta()
-		c := meta.(*DNSClient).c
-		srv_addr := meta.(*DNSClient).srv_addr
 
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypePTR)
-		r, _, err := c.Exchange(msg, srv_addr)
+		r, err := exchange(msg, false, meta)
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}


### PR DESCRIPTION
This should fix #29 and #16 (and obsolete #34).

I've added a common `exchange()` which removes a lot of the DNS query duplication and this also handles the case of UDP truncation by retrying with EDNS0 to set a bigger UDP size and then with TCP if necessary.

I added a simple truncation test case by having an AAAA RR with 14 addresses which is sufficient to exceed the 512 byte limit:
```
$ make testacc TEST=./dns TESTARGS='-run=TestAccDns*'                              
==> Checking that code complies with gofmt requirements...                         
TF_ACC=1 go test ./dns -v -run=TestAccDns* -timeout 120m                           
=== RUN   TestAccDnsARecordSet_Basic                                               
--- PASS: TestAccDnsARecordSet_Basic (0.13s)                                       
=== RUN   TestAccDnsAAAARecordSet_basic                                            
--- FAIL: TestAccDnsAAAARecordSet_basic (0.08s)                                    
        testing.go:434: Step 3 error: Error applying: 1 error(s) occurred:         
                                                                                   
                * dns_aaaa_record_set.bar: 1 error(s) occurred:                    
                                                                                   
                * dns_aaaa_record_set.bar: Error querying DNS record: dns: failed to unpack truncated message
        testing.go:494: Error destroying resource! WARNING: Dangling resources  
                may exist. The full state and error is shown below.                
                                                                                   
                Error: Error refreshing: 1 error(s) occurred:                      
                                                                                   
                * dns_aaaa_record_set.bar: 1 error(s) occurred:                    
                                                                                   
                * dns_aaaa_record_set.bar: dns_aaaa_record_set.bar: Error querying DNS record: dns: failed to unpack truncated message
                                                                                   
                State: <nil>                                                       
=== RUN   TestAccDnsCnameRecord_basic                                              
--- PASS: TestAccDnsCnameRecord_basic (0.07s)                                      
=== RUN   TestAccDnsNSRecordSet_Basic                                              
--- PASS: TestAccDnsNSRecordSet_Basic (0.07s)                                      
=== RUN   TestAccDnsPtrRecord_basic                                                
--- PASS: TestAccDnsPtrRecord_basic (0.07s)                                        
FAIL                                                                               
exit status 1                                                                      
FAIL    github.com/terraform-providers/terraform-provider-dns/dns       0.432s  
make: *** [testacc] Error 1                                                        
```
With the code fixed and also doing TSIG on reads, tests still pass:
```
$ make testacc TEST=./dns TESTARGS='-run=TestAccDns*'
==> Checking that code complies with gofmt requirements...
TF_ACC=1 go test ./dns -v -run=TestAccDns* -timeout 120m
=== RUN   TestAccDnsARecordSet_Basic
--- PASS: TestAccDnsARecordSet_Basic (0.07s)
=== RUN   TestAccDnsAAAARecordSet_basic
--- PASS: TestAccDnsAAAARecordSet_basic (0.10s)
=== RUN   TestAccDnsCnameRecord_basic
--- PASS: TestAccDnsCnameRecord_basic (0.07s)
=== RUN   TestAccDnsNSRecordSet_Basic
--- PASS: TestAccDnsNSRecordSet_Basic (0.07s)
=== RUN   TestAccDnsPtrRecord_basic
--- PASS: TestAccDnsPtrRecord_basic (0.06s)
PASS
ok  	github.com/terraform-providers/terraform-provider-dns/dns	0.379s
```