### PR TITLE
Validate TSIG key name and resource zone/record names

### DIFF
--- a/dns/resource_dns_a_record_set.go
+++ b/dns/resource_dns_a_record_set.go
@@ -17,14 +17,16 @@ func resourceDnsARecordSet() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"zone": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateZone,
 			},
 			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateName,
 			},
 			"addresses": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -47,10 +49,6 @@ func resourceDnsARecordSetCreate(d *schema.ResourceData, meta interface{}) error
 	rec_name := d.Get("name").(string)
 	rec_zone := d.Get("zone").(string)
 
-	if rec_zone != dns.Fqdn(rec_zone) {
-		return fmt.Errorf("Error creating DNS record: \"zone\" should be an FQDN")
-	}
-
 	rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
 	d.SetId(rec_fqdn)
@@ -64,10 +62,6 @@ func resourceDnsARecordSetRead(d *schema.ResourceData, meta interface{}) error {
 
 		rec_name := d.Get("name").(string)
 		rec_zone := d.Get("zone").(string)
-
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
@@ -130,10 +124,6 @@ func resourceDnsARecordSetUpdate(d *schema.ResourceData, meta interface{}) error
 		rec_zone := d.Get("zone").(string)
 		ttl := d.Get("ttl").(int)
 
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error updating DNS record: \"zone\" should be an FQDN")
-		}
-
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
 		msg := new(dns.Msg)
@@ -184,10 +174,6 @@ func resourceDnsARecordSetDelete(d *schema.ResourceData, meta interface{}) error
 
 		rec_name := d.Get("name").(string)
 		rec_zone := d.Get("zone").(string)
-
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error updating DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 

--- a/dns/resource_dns_a_record_set_test.go
+++ b/dns/resource_dns_a_record_set_test.go
@@ -76,10 +76,6 @@ func testAccCheckDnsARecordSetDestroy(s *terraform.State) error {
 		rec_name := rs.Primary.Attributes["name"]
 		rec_zone := rs.Primary.Attributes["zone"]
 
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
-
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
 		msg := new(dns.Msg)
@@ -108,10 +104,6 @@ func testAccCheckDnsARecordSetExists(t *testing.T, n string, addr []interface{},
 
 		*rec_name = rs.Primary.Attributes["name"]
 		*rec_zone = rs.Primary.Attributes["zone"]
-
-		if *rec_zone != dns.Fqdn(*rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", *rec_name, *rec_zone)
 

--- a/dns/resource_dns_aaaa_record_set.go
+++ b/dns/resource_dns_aaaa_record_set.go
@@ -17,14 +17,16 @@ func resourceDnsAAAARecordSet() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"zone": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateZone,
 			},
 			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateName,
 			},
 			"addresses": &schema.Schema{
 				Type:     schema.TypeSet,
@@ -47,10 +49,6 @@ func resourceDnsAAAARecordSetCreate(d *schema.ResourceData, meta interface{}) er
 	rec_name := d.Get("name").(string)
 	rec_zone := d.Get("zone").(string)
 
-	if rec_zone != dns.Fqdn(rec_zone) {
-		return fmt.Errorf("Error creating DNS record: \"zone\" should be an FQDN")
-	}
-
 	rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
 	d.SetId(rec_fqdn)
@@ -64,10 +62,6 @@ func resourceDnsAAAARecordSetRead(d *schema.ResourceData, meta interface{}) erro
 
 		rec_name := d.Get("name").(string)
 		rec_zone := d.Get("zone").(string)
-
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
@@ -130,10 +124,6 @@ func resourceDnsAAAARecordSetUpdate(d *schema.ResourceData, meta interface{}) er
 		rec_zone := d.Get("zone").(string)
 		ttl := d.Get("ttl").(int)
 
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error updating DNS record: \"zone\" should be an FQDN")
-		}
-
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
 		msg := new(dns.Msg)
@@ -184,10 +174,6 @@ func resourceDnsAAAARecordSetDelete(d *schema.ResourceData, meta interface{}) er
 
 		rec_name := d.Get("name").(string)
 		rec_zone := d.Get("zone").(string)
-
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error updating DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 

--- a/dns/resource_dns_aaaa_record_set_test.go
+++ b/dns/resource_dns_aaaa_record_set_test.go
@@ -83,10 +83,6 @@ func testAccCheckDnsAAAARecordSetDestroy(s *terraform.State) error {
 		rec_name := rs.Primary.Attributes["name"]
 		rec_zone := rs.Primary.Attributes["zone"]
 
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
-
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
 		msg := new(dns.Msg)
@@ -115,10 +111,6 @@ func testAccCheckDnsAAAARecordSetExists(t *testing.T, n string, addr []interface
 
 		*rec_name = rs.Primary.Attributes["name"]
 		*rec_zone = rs.Primary.Attributes["zone"]
-
-		if *rec_zone != dns.Fqdn(*rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", *rec_name, *rec_zone)
 

--- a/dns/resource_dns_cname_record.go
+++ b/dns/resource_dns_cname_record.go
@@ -16,18 +16,21 @@ func resourceDnsCnameRecord() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"zone": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateZone,
 			},
 			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateName,
 			},
 			"cname": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateZone,
 			},
 			"ttl": &schema.Schema{
 				Type:     schema.TypeInt,
@@ -43,15 +46,6 @@ func resourceDnsCnameRecordCreate(d *schema.ResourceData, meta interface{}) erro
 
 	rec_name := d.Get("name").(string)
 	rec_zone := d.Get("zone").(string)
-	rec_cname := d.Get("cname").(string)
-
-	if rec_zone != dns.Fqdn(rec_zone) {
-		return fmt.Errorf("Error creating DNS record: \"zone\" should be an FQDN")
-	}
-
-	if rec_cname != dns.Fqdn(rec_cname) {
-		return fmt.Errorf("Error creating DNS record: \"cname\" should be an FQDN")
-	}
 
 	rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
@@ -67,14 +61,6 @@ func resourceDnsCnameRecordRead(d *schema.ResourceData, meta interface{}) error 
 		rec_name := d.Get("name").(string)
 		rec_zone := d.Get("zone").(string)
 		rec_cname := d.Get("cname").(string)
-
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
-
-		if rec_cname != dns.Fqdn(rec_cname) {
-			return fmt.Errorf("Error reading DNS record: \"cname\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
@@ -119,16 +105,7 @@ func resourceDnsCnameRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 
 		rec_name := d.Get("name").(string)
 		rec_zone := d.Get("zone").(string)
-		rec_cname := d.Get("cname").(string)
 		ttl := d.Get("ttl").(int)
-
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error updating DNS record: \"zone\" should be an FQDN")
-		}
-
-		if rec_cname != dns.Fqdn(rec_cname) {
-			return fmt.Errorf("Error updating DNS record: \"cname\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
@@ -174,10 +151,6 @@ func resourceDnsCnameRecordDelete(d *schema.ResourceData, meta interface{}) erro
 
 		rec_name := d.Get("name").(string)
 		rec_zone := d.Get("zone").(string)
-
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error updating DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 

--- a/dns/resource_dns_cname_record_test.go
+++ b/dns/resource_dns_cname_record_test.go
@@ -72,10 +72,6 @@ func testAccCheckDnsCnameRecordDestroy(s *terraform.State) error {
 		rec_name := rs.Primary.Attributes["name"]
 		rec_zone := rs.Primary.Attributes["zone"]
 
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
-
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
 		msg := new(dns.Msg)
@@ -104,10 +100,6 @@ func testAccCheckDnsCnameRecordExists(t *testing.T, n string, expected string, r
 
 		*rec_name = rs.Primary.Attributes["name"]
 		*rec_zone = rs.Primary.Attributes["zone"]
-
-		if *rec_zone != dns.Fqdn(*rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", *rec_name, *rec_zone)
 

--- a/dns/resource_dns_ns_record_set.go
+++ b/dns/resource_dns_ns_record_set.go
@@ -16,20 +16,25 @@ func resourceDnsNSRecordSet() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"zone": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateZone,
 			},
 			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateName,
 			},
 			"nameservers": &schema.Schema{
 				Type:     schema.TypeSet,
 				Required: true,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Set:      schema.HashString,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validateZone,
+				},
+				Set: schema.HashString,
 			},
 			"ttl": &schema.Schema{
 				Type:     schema.TypeInt,
@@ -46,10 +51,6 @@ func resourceDnsNSRecordSetCreate(d *schema.ResourceData, meta interface{}) erro
 	rec_name := d.Get("name").(string)
 	rec_zone := d.Get("zone").(string)
 
-	if rec_zone != dns.Fqdn(rec_zone) {
-		return fmt.Errorf("Error creating DNS record: \"zone\" should be an FQDN")
-	}
-
 	rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
 	d.SetId(rec_fqdn)
@@ -63,10 +64,6 @@ func resourceDnsNSRecordSetRead(d *schema.ResourceData, meta interface{}) error 
 
 		rec_name := d.Get("name").(string)
 		rec_zone := d.Get("zone").(string)
-
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
@@ -116,10 +113,6 @@ func resourceDnsNSRecordSetUpdate(d *schema.ResourceData, meta interface{}) erro
 		rec_name := d.Get("name").(string)
 		rec_zone := d.Get("zone").(string)
 		ttl := d.Get("ttl").(int)
-
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error updating DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
@@ -171,10 +164,6 @@ func resourceDnsNSRecordSetDelete(d *schema.ResourceData, meta interface{}) erro
 
 		rec_name := d.Get("name").(string)
 		rec_zone := d.Get("zone").(string)
-
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error updating DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 

--- a/dns/resource_dns_ns_record_set_test.go
+++ b/dns/resource_dns_ns_record_set_test.go
@@ -76,10 +76,6 @@ func testAccCheckDnsNSRecordSetDestroy(s *terraform.State) error {
 		rec_name := rs.Primary.Attributes["name"]
 		rec_zone := rs.Primary.Attributes["zone"]
 
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
-
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
 		msg := new(dns.Msg)
@@ -109,10 +105,6 @@ func testAccCheckDnsNSRecordSetExists(t *testing.T, n string, nameserver []inter
 
 		*rec_name = rs.Primary.Attributes["name"]
 		*rec_zone = rs.Primary.Attributes["zone"]
-
-		if *rec_zone != dns.Fqdn(*rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", *rec_name, *rec_zone)
 

--- a/dns/resource_dns_ptr_record.go
+++ b/dns/resource_dns_ptr_record.go
@@ -16,18 +16,21 @@ func resourceDnsPtrRecord() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"zone": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateZone,
 			},
 			"name": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateName,
 			},
 			"ptr": &schema.Schema{
-				Type:     schema.TypeString,
-				Required: true,
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validateZone,
 			},
 			"ttl": &schema.Schema{
 				Type:     schema.TypeInt,
@@ -43,15 +46,6 @@ func resourceDnsPtrRecordCreate(d *schema.ResourceData, meta interface{}) error 
 
 	rec_name := d.Get("name").(string)
 	rec_zone := d.Get("zone").(string)
-	rec_ptr := d.Get("ptr").(string)
-
-	if rec_zone != dns.Fqdn(rec_zone) {
-		return fmt.Errorf("Error creating DNS record: \"zone\" should be an FQDN")
-	}
-
-	if rec_ptr != dns.Fqdn(rec_ptr) {
-		return fmt.Errorf("Error creating DNS record: \"ptr\" should be an FQDN")
-	}
 
 	rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
@@ -67,14 +61,6 @@ func resourceDnsPtrRecordRead(d *schema.ResourceData, meta interface{}) error {
 		rec_name := d.Get("name").(string)
 		rec_zone := d.Get("zone").(string)
 		rec_ptr := d.Get("ptr").(string)
-
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
-
-		if rec_ptr != dns.Fqdn(rec_ptr) {
-			return fmt.Errorf("Error reading DNS record: \"ptr\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
@@ -119,16 +105,7 @@ func resourceDnsPtrRecordUpdate(d *schema.ResourceData, meta interface{}) error 
 
 		rec_name := d.Get("name").(string)
 		rec_zone := d.Get("zone").(string)
-		rec_ptr := d.Get("ptr").(string)
 		ttl := d.Get("ttl").(int)
-
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error updating DNS record: \"zone\" should be an FQDN")
-		}
-
-		if rec_ptr != dns.Fqdn(rec_ptr) {
-			return fmt.Errorf("Error updating DNS record: \"ptr\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
@@ -174,10 +151,6 @@ func resourceDnsPtrRecordDelete(d *schema.ResourceData, meta interface{}) error 
 
 		rec_name := d.Get("name").(string)
 		rec_zone := d.Get("zone").(string)
-
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error updating DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 

--- a/dns/resource_dns_ptr_record_test.go
+++ b/dns/resource_dns_ptr_record_test.go
@@ -72,10 +72,6 @@ func testAccCheckDnsPtrRecordDestroy(s *terraform.State) error {
 		rec_name := rs.Primary.Attributes["name"]
 		rec_zone := rs.Primary.Attributes["zone"]
 
-		if rec_zone != dns.Fqdn(rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
-
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
 		msg := new(dns.Msg)
@@ -104,10 +100,6 @@ func testAccCheckDnsPtrRecordExists(t *testing.T, n string, expected string, rec
 
 		*rec_name = rs.Primary.Attributes["name"]
 		*rec_zone = rs.Primary.Attributes["zone"]
-
-		if *rec_zone != dns.Fqdn(*rec_zone) {
-			return fmt.Errorf("Error reading DNS record: \"zone\" should be an FQDN")
-		}
 
 		rec_fqdn := fmt.Sprintf("%s.%s", *rec_name, *rec_zone)
 

--- a/dns/validators.go
+++ b/dns/validators.go
@@ -1,0 +1,23 @@
+package dns
+
+import (
+	"fmt"
+
+	"github.com/miekg/dns"
+)
+
+func validateZone(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if !dns.IsFqdn(value) {
+		errors = append(errors, fmt.Errorf("DNS zone name %q must be fully qualified: %q", k, value))
+	}
+	return
+}
+
+func validateName(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	if dns.IsFqdn(value) {
+		errors = append(errors, fmt.Errorf("DNS record name %q must not be fully qualified: %q", k, value))
+	}
+	return
+}

--- a/dns/validators_test.go
+++ b/dns/validators_test.go
@@ -1,0 +1,49 @@
+package dns
+
+import (
+	"testing"
+)
+
+func TestValidateZone(t *testing.T) {
+	validNames := []string{
+		"example.com.",
+	}
+	for _, v := range validNames {
+		_, errors := validateZone(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid DNS zone: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"example.com",
+	}
+	for _, v := range invalidNames {
+		_, errors := validateZone(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid DNS zone", v)
+		}
+	}
+}
+
+func TestValidateName(t *testing.T) {
+	validNames := []string{
+		"test",
+	}
+	for _, v := range validNames {
+		_, errors := validateName(v, "name")
+		if len(errors) != 0 {
+			t.Fatalf("%q should be a valid DNS record: %q", v, errors)
+		}
+	}
+
+	invalidNames := []string{
+		"test.",
+	}
+	for _, v := range invalidNames {
+		_, errors := validateName(v, "name")
+		if len(errors) == 0 {
+			t.Fatalf("%q should be an invalid DNS record", v)
+		}
+	}
+}


### PR DESCRIPTION
This should fix #24, #19 & #15.

Basically check the TSIG key name is fully-qualified and all lower-case. For resources, validate the zone name is fully qualified and that the record name isn't, due to them being joined with `"%s.%s"` so it should prevent double `".."` which seems to be a common source of misconfiguration.