### PR TITLE
checking type on Get*Val(record interface{}) like functions

### DIFF
--- a/dns/provider.go
+++ b/dns/provider.go
@@ -145,10 +145,10 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 
 func getAVal(record interface{}) (string, error) {
 
-  _, ok := record.(*dns.A)
-  if !ok {
-    return "", fmt.Errorf("didn't get a A record")
-  }
+	_, ok := record.(*dns.A)
+	if !ok {
+		return "", fmt.Errorf("didn't get a A record")
+	}
 
 	recstr := record.(*dns.A).String()
 	var name, ttl, class, typ, addr string
@@ -163,10 +163,10 @@ func getAVal(record interface{}) (string, error) {
 
 func getNSVal(record interface{}) (string, error) {
 
-  _, ok := record.(*dns.NS)
-  if !ok {
-    return "", fmt.Errorf("didn't get a NS record")
-  }
+	_, ok := record.(*dns.NS)
+	if !ok {
+		return "", fmt.Errorf("didn't get a NS record")
+	}
 
 	recstr := record.(*dns.NS).String()
 	var name, ttl, class, typ, nameserver string
@@ -181,10 +181,10 @@ func getNSVal(record interface{}) (string, error) {
 
 func getAAAAVal(record interface{}) (string, error) {
 
-  _, ok := record.(*dns.AAAA)
-  if !ok {
-    return "", fmt.Errorf("didn't get a AAAA record")
-  }
+	_, ok := record.(*dns.AAAA)
+	if !ok {
+		return "", fmt.Errorf("didn't get a AAAA record")
+	}
 
 	recstr := record.(*dns.AAAA).String()
 	var name, ttl, class, typ, addr string
@@ -199,10 +199,10 @@ func getAAAAVal(record interface{}) (string, error) {
 
 func getCnameVal(record interface{}) (string, error) {
 
-  _, ok := record.(*dns.CNAME)
-  if !ok {
-    return "", fmt.Errorf("didn't get a CNAME record")
-  }
+	_, ok := record.(*dns.CNAME)
+	if !ok {
+		return "", fmt.Errorf("didn't get a CNAME record")
+	}
 
 	recstr := record.(*dns.CNAME).String()
 	var name, ttl, class, typ, cname string
@@ -217,10 +217,10 @@ func getCnameVal(record interface{}) (string, error) {
 
 func getPtrVal(record interface{}) (string, error) {
 
-  _, ok := record.(*dns.PTR)
-  if !ok {
-    return "", fmt.Errorf("didn't get a PTR record")
-  }
+	_, ok := record.(*dns.PTR)
+	if !ok {
+		return "", fmt.Errorf("didn't get a PTR record")
+	}
 
 	recstr := record.(*dns.PTR).String()
 	var name, ttl, class, typ, ptr string

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -145,6 +145,11 @@ func configureProvider(d *schema.ResourceData) (interface{}, error) {
 
 func getAVal(record interface{}) (string, error) {
 
+  _, ok := record.(*dns.A)
+  if !ok {
+    return "", fmt.Errorf("didn't get a A record")
+  }
+
 	recstr := record.(*dns.A).String()
 	var name, ttl, class, typ, addr string
 
@@ -157,6 +162,11 @@ func getAVal(record interface{}) (string, error) {
 }
 
 func getNSVal(record interface{}) (string, error) {
+
+  _, ok := record.(*dns.NS)
+  if !ok {
+    return "", fmt.Errorf("didn't get a NS record")
+  }
 
 	recstr := record.(*dns.NS).String()
 	var name, ttl, class, typ, nameserver string
@@ -171,6 +181,11 @@ func getNSVal(record interface{}) (string, error) {
 
 func getAAAAVal(record interface{}) (string, error) {
 
+  _, ok := record.(*dns.AAAA)
+  if !ok {
+    return "", fmt.Errorf("didn't get a AAAA record")
+  }
+
 	recstr := record.(*dns.AAAA).String()
 	var name, ttl, class, typ, addr string
 
@@ -184,6 +199,11 @@ func getAAAAVal(record interface{}) (string, error) {
 
 func getCnameVal(record interface{}) (string, error) {
 
+  _, ok := record.(*dns.CNAME)
+  if !ok {
+    return "", fmt.Errorf("didn't get a CNAME record")
+  }
+
 	recstr := record.(*dns.CNAME).String()
 	var name, ttl, class, typ, cname string
 
@@ -196,6 +216,11 @@ func getCnameVal(record interface{}) (string, error) {
 }
 
 func getPtrVal(record interface{}) (string, error) {
+
+  _, ok := record.(*dns.PTR)
+  if !ok {
+    return "", fmt.Errorf("didn't get a PTR record")
+  }
 
 	recstr := record.(*dns.PTR).String()
 	var name, ttl, class, typ, ptr string


### PR DESCRIPTION
Greetings,

a few Get*Val() funcs are defined in dns/provider.go
example for a A record:
```
func getAVal(record interface{}) (string, error) {

    recstr := record.(*dns.A).String()
...
```

but no type check is performed before casting

We had an issue where a `dns_a_record_set` was defined but somehow the people managing the DNS zone changed the record to a CNAME record using external tools

The crash log exhibited the exact issue:
```
* dns_a_record_set.test: dns_a_record_set.test: unexpected EOF
panic: interface conversion: interface {} is *dns.CNAME, not *dns.A
2018-03-22T14:39:09.468Z [DEBUG] plugin.terraform-provider-dns_v1.0.0_x4:
2018-03-22T14:39:09.468Z [DEBUG] plugin.terraform-provider-dns_v1.0.0_x4: goroutine 25 [running]:
2018-03-22T14:39:09.468Z [DEBUG] plugin.terraform-provider-dns_v1.0.0_x4: github.com/terraform-providers/terraform-provider-dns/dns.getAVal(0xb3f380, 0xc42033e420, 0x0, 0x0, 0xc4203326e0, 0x39b7c3)
2018-03-22T14:39:09.468Z [DEBUG] plugin.terraform-provider-dns_v1.0.0_x4:       /opt/teamcity-agent/work/222ea50a1b4f75f4/src/github.com/terraform-providers/terraform-provider-dns/dns/provider.go:146 +0x2e6
...
```

This PR attempts to handle this edge case more gently;
as DNS RR are first class citizen we can't perform a clean remove & add but at least it will no lead to a panic()

thanks to @dstoffel-de for reporting the issue and testing the patch