### PR TITLE
Fix hashi_txts output syntax

### DIFF
--- a/website/docs/d/dns_txt_record_set.html.markdown
+++ b/website/docs/d/dns_txt_record_set.html.markdown
@@ -22,7 +22,7 @@ output "hashi_txt" {
 }
 
 output "hashi_txts" {
-  value = "${join(",", data.dns_txt_record_set.hashi.records})"
+  value = "${join(",", data.dns_txt_record_set.hashi.records)}"
 }
 ```
 


### PR DESCRIPTION
I copied the example from the doc and noticed this syntax error. 