### PR TITLE
feature: allow specifying transport type + timeout

### DIFF
--- a/dns/config.go
+++ b/dns/config.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/miekg/dns"
 )
@@ -16,6 +17,8 @@ type Config struct {
 	keyname   string
 	keyalgo   string
 	keysecret string
+	transport string
+	timeout   int
 }
 
 type DNSClient struct {
@@ -24,6 +27,8 @@ type DNSClient struct {
 	keyname   string
 	keysecret string
 	keyalgo   string
+	transport string
+	timeout   time.Duration
 }
 
 // Configures and returns a fully initialized DNSClient
@@ -55,6 +60,8 @@ func (c *Config) Client() (interface{}, error) {
 		client.keyalgo = keyalgo
 		client.c.TsigSecret = map[string]string{keyname: c.keysecret}
 	}
+	client.transport = c.transport
+	client.timeout = time.Duration(c.timeout) * time.Second
 	return &client, nil
 }
 


### PR DESCRIPTION
This allows `terraform-provider-dns` users to use TCP and to tune the timeout if they so wish. I've found TCP to be a bit more stable, paired with `-parallelism=20`, than UDP.