### PR TITLE
data_dns_mx_record_set: Implement data source for MX

### DIFF
--- a/dns/data_dns_mx_record_set.go
+++ b/dns/data_dns_mx_record_set.go
@@ -1,0 +1,47 @@
+package dns
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceDnsMXRecordSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDnsMXRecordSetRead,
+		Schema: map[string]*schema.Schema{
+			"host": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"mxservers": &schema.Schema{
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDnsMXRecordSetRead(d *schema.ResourceData, meta interface{}) error {
+	host := d.Get("host").(string)
+
+	mxRecords, err := net.LookupMX(host)
+	if err != nil {
+		return fmt.Errorf("error looking up MX records for %q: %s", host, err)
+	}
+
+	mxservers := make([]string, len(mxRecords))
+	for i, record := range mxRecords {
+		mxservers[i] = record.Host
+	}
+
+	err = d.Set("mxservers", mxservers)
+	if err != nil {
+		return err
+	}
+	d.SetId(host)
+
+	return nil
+}

--- a/dns/data_dns_mx_record_set.go
+++ b/dns/data_dns_mx_record_set.go
@@ -3,6 +3,7 @@ package dns
 import (
 	"fmt"
 	"net"
+	"sort"
 
 	"github.com/hashicorp/terraform/helper/schema"
 )
@@ -20,6 +21,11 @@ func dataSourceDnsMXRecordSet() *schema.Resource {
 				Elem:     &schema.Schema{Type: schema.TypeString},
 				Computed: true,
 			},
+			"priorities": &schema.Schema{
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeInt},
+				Computed: true,
+			},
 		},
 	}
 }
@@ -32,15 +38,33 @@ func dataSourceDnsMXRecordSetRead(d *schema.ResourceData, meta interface{}) erro
 		return fmt.Errorf("error looking up MX records for %q: %s", zone, err)
 	}
 
-	mxservers := make([]string, len(mxRecords))
-	for i, record := range mxRecords {
-		mxservers[i] = record.Host
+	m := make(map[string]int)
+	for _, record := range mxRecords {
+		m[record.Host] = int(record.Pref)
+	}
+	//List of mxservers sorted by name, not priority
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	mxservers := make([]string, 0, len(m))
+	priorities := make([]int, 0, len(m))
+	for _, k := range keys {
+		mxservers = append(mxservers, k)
+		priorities = append(priorities, m[k])
 	}
 
 	err = d.Set("mxservers", mxservers)
 	if err != nil {
 		return err
 	}
+
+	err = d.Set("priorities", priorities)
+	if err != nil {
+		return err
+	}
+
 	d.SetId(zone)
 
 	return nil

--- a/dns/data_dns_mx_record_set.go
+++ b/dns/data_dns_mx_record_set.go
@@ -11,7 +11,7 @@ func dataSourceDnsMXRecordSet() *schema.Resource {
 	return &schema.Resource{
 		Read: dataSourceDnsMXRecordSetRead,
 		Schema: map[string]*schema.Schema{
-			"host": &schema.Schema{
+			"zone": &schema.Schema{
 				Type:     schema.TypeString,
 				Required: true,
 			},
@@ -25,11 +25,11 @@ func dataSourceDnsMXRecordSet() *schema.Resource {
 }
 
 func dataSourceDnsMXRecordSetRead(d *schema.ResourceData, meta interface{}) error {
-	host := d.Get("host").(string)
+	zone := d.Get("zone").(string)
 
-	mxRecords, err := net.LookupMX(host)
+	mxRecords, err := net.LookupMX(zone)
 	if err != nil {
-		return fmt.Errorf("error looking up MX records for %q: %s", host, err)
+		return fmt.Errorf("error looking up MX records for %q: %s", zone, err)
 	}
 
 	mxservers := make([]string, len(mxRecords))
@@ -41,7 +41,7 @@ func dataSourceDnsMXRecordSetRead(d *schema.ResourceData, meta interface{}) erro
 	if err != nil {
 		return err
 	}
-	d.SetId(host)
+	d.SetId(zone)
 
 	return nil
 }

--- a/dns/data_dns_mx_record_set_test.go
+++ b/dns/data_dns_mx_record_set_test.go
@@ -12,6 +12,7 @@ func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
 		DataSourceBlock string
 		DataSourceName  string
 		Expected        []string
+		Priority        []int
 		Zone            string
 	}{
 		{
@@ -31,7 +32,46 @@ func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
 				"eforward4.registrar-servers.com.",
 				"eforward5.registrar-servers.com.",
 			},
+			[]int{
+				// These results may change if hashicorp.net changes MX host priorities, hosts, or providers.
+				// If you suspect the expected results have changed here, confirm
+				// with e.g. dig hashicorp.net MX +short
+				10,
+				10,
+				10,
+				15,
+				20,
+			},
 			"hashicorp.net",
+		},
+		{
+			`
+			data "dns_mx_record_set" "foo" {
+			zone = "google.com"
+			}
+			`,
+			"foo",
+			[]string{
+				// These results may change if google.com changes MX hosts or providers.
+				// If you suspect the expected results have changed here, confirm
+				// with e.g. dig google.com MX +short
+				"alt1.aspmx.l.google.com.",
+				"alt2.aspmx.l.google.com.",
+				"alt3.aspmx.l.google.com.",
+				"alt4.aspmx.l.google.com.",
+				"aspmx.l.google.com.",
+			},
+			[]int{
+				// These results may change if hashicorp.net changes MX host priorities, hosts, or providers.
+				// If you suspect the expected results have changed here, confirm
+				// with e.g. dig hashicorp.net MX +short
+				20,
+				30,
+				40,
+				50,
+				10,
+			},
+			"google.com",
 		},
 	}
 
@@ -45,6 +85,12 @@ func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
 					Config: test.DataSourceBlock,
 					Check: resource.ComposeTestCheckFunc(
 						testCheckAttrStringArray(recordName, "mxservers", test.Expected),
+					),
+				},
+				{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						testCheckAttrIntArray(recordName, "priorities", test.Priority),
 					),
 				},
 				{

--- a/dns/data_dns_mx_record_set_test.go
+++ b/dns/data_dns_mx_record_set_test.go
@@ -26,21 +26,21 @@ func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
 				// These results may change if hashicorptest.com changes MX hosts or providers.
 				// If you suspect the expected results have changed here, confirm
 				// with e.g. dig hashicorptest.com MX +short
+				"aspmx.l.google.com.",
 				"alt1.aspmx.l.google.com.",
 				"alt2.aspmx.l.google.com.",
 				"alt3.aspmx.l.google.com.",
 				"alt4.aspmx.l.google.com.",
-				"aspmx.l.google.com.",
 			},
 			[]int{
 				// These results may change if hashicorptest.com changes MX host priorities, hosts, or providers.
 				// If you suspect the expected results have changed here, confirm
 				// with e.g. dig hashicorptest.net MX +short
-				5,
-				5,
-				10,
-				10,
 				1,
+				5,
+				5,
+				10,
+				10,
 			},
 			"hashicorptest.com",
 		},
@@ -55,13 +55,13 @@ func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
 				{
 					Config: test.DataSourceBlock,
 					Check: resource.ComposeTestCheckFunc(
-						testCheckAttrStringArray(recordName, "mxservers", test.Expected),
+						testCheckAttrOrderedStringArray(recordName, "mxservers", test.Expected),
 					),
 				},
 				{
 					Config: test.DataSourceBlock,
 					Check: resource.ComposeTestCheckFunc(
-						testCheckAttrIntArray(recordName, "priorities", test.Priority),
+						testCheckAttrOrderedIntArray(recordName, "priorities", test.Priority),
 					),
 				},
 				{

--- a/dns/data_dns_mx_record_set_test.go
+++ b/dns/data_dns_mx_record_set_test.go
@@ -12,12 +12,12 @@ func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
 		DataSourceBlock string
 		DataSourceName  string
 		Expected        []string
-		Host            string
+		Zone            string
 	}{
 		{
 			`
 			data "dns_mx_record_set" "foo" {
-			  host = "hashicorp.net"
+			  zone = "hashicorp.net"
 			}
 			`,
 			"foo",
@@ -50,7 +50,7 @@ func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
 				{
 					Config: test.DataSourceBlock,
 					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr(recordName, "id", test.Host),
+						resource.TestCheckResourceAttr(recordName, "id", test.Zone),
 					),
 				},
 			},

--- a/dns/data_dns_mx_record_set_test.go
+++ b/dns/data_dns_mx_record_set_test.go
@@ -18,43 +18,14 @@ func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
 		{
 			`
 			data "dns_mx_record_set" "foo" {
-			  zone = "hashicorp.net"
+			zone = "hashicorptest.com"
 			}
 			`,
 			"foo",
 			[]string{
-				// These results may change if hashicorp.net changes MX hosts or providers.
+				// These results may change if hashicorptest.com changes MX hosts or providers.
 				// If you suspect the expected results have changed here, confirm
-				// with e.g. dig hashicorp.net MX +short
-				"eforward1.registrar-servers.com.",
-				"eforward2.registrar-servers.com.",
-				"eforward3.registrar-servers.com.",
-				"eforward4.registrar-servers.com.",
-				"eforward5.registrar-servers.com.",
-			},
-			[]int{
-				// These results may change if hashicorp.net changes MX host priorities, hosts, or providers.
-				// If you suspect the expected results have changed here, confirm
-				// with e.g. dig hashicorp.net MX +short
-				10,
-				10,
-				10,
-				15,
-				20,
-			},
-			"hashicorp.net",
-		},
-		{
-			`
-			data "dns_mx_record_set" "foo" {
-			zone = "google.com"
-			}
-			`,
-			"foo",
-			[]string{
-				// These results may change if google.com changes MX hosts or providers.
-				// If you suspect the expected results have changed here, confirm
-				// with e.g. dig google.com MX +short
+				// with e.g. dig hashicorptest.com MX +short
 				"alt1.aspmx.l.google.com.",
 				"alt2.aspmx.l.google.com.",
 				"alt3.aspmx.l.google.com.",
@@ -62,16 +33,16 @@ func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
 				"aspmx.l.google.com.",
 			},
 			[]int{
-				// These results may change if hashicorp.net changes MX host priorities, hosts, or providers.
+				// These results may change if hashicorptest.com changes MX host priorities, hosts, or providers.
 				// If you suspect the expected results have changed here, confirm
-				// with e.g. dig hashicorp.net MX +short
-				20,
-				30,
-				40,
-				50,
+				// with e.g. dig hashicorptest.net MX +short
+				5,
+				5,
 				10,
+				10,
+				1,
 			},
-			"google.com",
+			"hashicorptest.com",
 		},
 	}
 

--- a/dns/data_dns_mx_record_set_test.go
+++ b/dns/data_dns_mx_record_set_test.go
@@ -1,0 +1,60 @@
+package dns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
+	tests := []struct {
+		DataSourceBlock string
+		DataSourceName  string
+		Expected        []string
+		Host            string
+	}{
+		{
+			`
+			data "dns_mx_record_set" "foo" {
+			  host = "hashicorp.net"
+			}
+			`,
+			"foo",
+			[]string{
+				// These results may change if hashicorp.net changes MX hosts or providers.
+				// If you suspect the expected results have changed here, confirm
+				// with e.g. dig hashicorp.net MX +short
+				"eforward1.registrar-servers.com.",
+				"eforward2.registrar-servers.com.",
+				"eforward3.registrar-servers.com.",
+				"eforward4.registrar-servers.com.",
+				"eforward5.registrar-servers.com.",
+			},
+			"hashicorp.net",
+		},
+	}
+
+	for _, test := range tests {
+		recordName := fmt.Sprintf("data.dns_mx_record_set.%s", test.DataSourceName)
+
+		resource.Test(t, resource.TestCase{
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						testCheckAttrStringArray(recordName, "mxservers", test.Expected),
+					),
+				},
+				{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(recordName, "id", test.Host),
+					),
+				},
+			},
+		})
+	}
+
+}

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -67,6 +67,7 @@ func Provider() terraform.ResourceProvider {
 			"dns_aaaa_record_set":  dataSourceDnsAAAARecordSet(),
 			"dns_cname_record_set": dataSourceDnsCnameRecordSet(),
 			"dns_txt_record_set":   dataSourceDnsTxtRecordSet(),
+			"dns_mx_record_set":    dataSourceDnsMXRecordSet(),
 			"dns_ns_record_set":    dataSourceDnsNSRecordSet(),
 			"dns_ptr_record_set":   dataSourceDnsPtrRecordSet(),
 		},

--- a/dns/test_check_attr_int_array.go
+++ b/dns/test_check_attr_int_array.go
@@ -1,0 +1,61 @@
+package dns
+
+import (
+	"fmt"
+	"strconv"
+
+	r "github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func testCheckAttrIntArray(name, key string, value []int) r.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ms := s.RootModule()
+		rs, ok := ms.Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		is := rs.Primary
+		if is == nil {
+			return fmt.Errorf("No primary instance: %s", name)
+		}
+
+		attrKey := fmt.Sprintf("%s.#", key)
+		count, ok := is.Attributes[attrKey]
+		if !ok {
+			return fmt.Errorf("Attributes not found for %s", attrKey)
+		}
+
+		gotCount, _ := strconv.Atoi(count)
+		if gotCount != len(value) {
+			return fmt.Errorf("Mismatch array count for %s: got %s, wanted %d", key, count, len(value))
+		}
+
+	Next:
+		for i := 0; i < gotCount; i++ {
+			attrKey = fmt.Sprintf("%s.%d", key, i)
+			got, ok := is.Attributes[attrKey]
+			if !ok {
+				return fmt.Errorf("Missing array item for %s", attrKey)
+			}
+			intGot, _ := strconv.Atoi(got)
+			//for _, want := range value {
+			//	fmt.Println(intGot, want)
+			//	if intGot == want {
+			//		continue Next
+			//	}
+			//}
+			if intGot == value[i] {
+				continue Next
+			}
+			return fmt.Errorf(
+				"Unexpected array item for %s: expected %d, got %s",
+				attrKey,
+				value[i],
+				got)
+		}
+
+		return nil
+	}
+}

--- a/dns/test_check_attr_ordered_string_array.go
+++ b/dns/test_check_attr_ordered_string_array.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform/terraform"
 )
 
-func testCheckAttrOrderedIntArray(name, key string, value []int) r.TestCheckFunc {
+func testCheckAttrOrderedStringArray(name, key string, value []string) r.TestCheckFunc {
 	return func(s *terraform.State) error {
 		ms := s.RootModule()
 		rs, ok := ms.Resources[name]
@@ -39,12 +39,11 @@ func testCheckAttrOrderedIntArray(name, key string, value []int) r.TestCheckFunc
 			if !ok {
 				return fmt.Errorf("Missing array item for %s", attrKey)
 			}
-			intGot, _ := strconv.Atoi(got)
-			if intGot == value[i] {
+			if got == value[i] {
 				continue Next
 			}
 			return fmt.Errorf(
-				"Unexpected array item for %s: expected %d, got %s",
+				"Unexpected array item for %s: expected %s, got %s",
 				attrKey,
 				value[i],
 				got)

--- a/website/dns.erb
+++ b/website/dns.erb
@@ -22,7 +22,10 @@
                         </li>
                         <li<%= sidebar_current("docs-dns-datasource-cname-record-set") %>>
                             <a href="/docs/providers/dns/d/dns_cname_record_set.html">dns_cname_record_set</a>
-                        </li>
+			</li>
+			<li<%= sidebar_current("docs-dns-datasource-mx-record-set") %>>
+			    <a href="/docs/providers/dns/d/dns_mx_record_set.html">dns_mx_record_set</a>
+			</li>
                         <li<%= sidebar_current("docs-dns-datasource-ns-record-set") %>>
                             <a href="/docs/providers/dns/d/dns_ns_record_set.html">dns_ns_record_set</a>
                         </li>

--- a/website/docs/d/dns_mx_record_set.html.markdown
+++ b/website/docs/d/dns_mx_record_set.html.markdown
@@ -34,4 +34,4 @@ The following attributes are exported:
 
  * `id` - Set to `zone`.
 
- * `mxservers` - A list of nameservers. Nameservers are always sorted to avoid constant changing plans.
+ * `mxservers` - A list of MX servers. MX servers are returned in priority order.

--- a/website/docs/d/dns_mx_record_set.html.markdown
+++ b/website/docs/d/dns_mx_record_set.html.markdown
@@ -1,0 +1,37 @@
+---
+layout: "dns"
+page_title: "DNS: dns_mx_record_set"
+sidebar_current: "docs-dns-datasource-mx-record-set"
+description: |-
+  Get DNS mx record set.
+---
+
+# dns_mx_record_set
+
+Use this data source to get DNS mx records of the zone.
+
+## Example Usage
+
+```hcl
+data "dns_mx_record_set" "google" {
+  host = "google.com"
+}
+
+output "google_mxservers" {
+  value = "${join(",", data.dns_mx_record_set.google.mxservers)}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+ * `zone` - (required): Zone to look up
+
+## Attributes Reference
+
+The following attributes are exported:
+
+ * `id` - Set to `zone`.
+
+ * `mxservers` - A list of nameservers. Nameservers are always sorted to avoid constant changing plans.

--- a/website/docs/d/dns_mx_record_set.html.markdown
+++ b/website/docs/d/dns_mx_record_set.html.markdown
@@ -14,7 +14,7 @@ Use this data source to get DNS mx records of the zone.
 
 ```hcl
 data "dns_mx_record_set" "google" {
-  host = "google.com"
+  zone = "google.com"
 }
 
 output "google_mxservers" {

--- a/website/docs/d/dns_mx_record_set.html.markdown
+++ b/website/docs/d/dns_mx_record_set.html.markdown
@@ -20,6 +20,10 @@ data "dns_mx_record_set" "google" {
 output "google_mxservers" {
   value = "${join(",", data.dns_mx_record_set.google.mxservers)}"
 }
+
+output "google_mxserver_priorities" {
+  value = "${join(",", data.dns_mx_record_set.google.priorities)}"
+}
 ```
 
 ## Argument Reference
@@ -36,4 +40,4 @@ The following attributes are exported:
 
  * `mxservers` - A list of MX servers. MX servers are sorted to avoid constant changing plans.
 
- * `priorities` - A list of MX server priorities corresponding to the mxserver list entries
+ * `priorities` - A list of MX server priorities corresponding to the mxserver list entries.

--- a/website/docs/d/dns_mx_record_set.html.markdown
+++ b/website/docs/d/dns_mx_record_set.html.markdown
@@ -34,4 +34,6 @@ The following attributes are exported:
 
  * `id` - Set to `zone`.
 
- * `mxservers` - A list of MX servers. MX servers are returned in priority order.
+ * `mxservers` - A list of MX servers. MX servers are sorted to avoid constant changing plans.
+
+ * `priorities` - A list of MX server priorities corresponding to the mxserver list entries

--- a/website/docs/d/dns_mx_record_set.html.markdown
+++ b/website/docs/d/dns_mx_record_set.html.markdown
@@ -38,6 +38,6 @@ The following attributes are exported:
 
  * `id` - Set to `zone`.
 
- * `mxservers` - A list of MX servers. MX servers are sorted to avoid constant changing plans.
+ * `mxservers` - A list of MX servers. MX servers are sorted first by priority and then by name to avoid changing plans.
 
  * `priorities` - A list of MX server priorities corresponding to the mxserver list entries.


### PR DESCRIPTION
These additions should allow a user to query a zone for all MX records.
Results are first sorted by priority and then MX server name to make results consistent between runs.

Related to:
https://github.com/terraform-providers/terraform-provider-dns/issues/51

Current test implemented with zone/domain: hashicorptest.com