### PR TITLE
bugfix: i/o timeout

### DIFF
--- a/dns/provider.go
+++ b/dns/provider.go
@@ -260,7 +260,9 @@ Retry:
 	r, _, err := c.Exchange(msg, srv_addr)
 
 	switch err {
-	case dns.ErrTruncated:
+	case nil:
+		return r, nil
+	default:
 		if retry_tcp {
 			switch c.Net {
 			case "udp":
@@ -269,6 +271,10 @@ Retry:
 				c.Net = "tcp4"
 			case "udp6":
 				c.Net = "tcp6"
+			case "tcp":
+				c.Net = "udp"
+			case "":
+				c.Net = "tcp"
 			default:
 				return nil, fmt.Errorf("Unknown transport: %s", c.Net)
 			}
@@ -278,13 +284,7 @@ Retry:
 		}
 
 		goto Retry
-	case nil:
-		fallthrough
-	default:
-		// do nothing
 	}
-
-	return r, err
 }
 
 func resourceDnsImport(d *schema.ResourceData, meta interface{}) ([]*schema.ResourceData, error) {

--- a/dns/resource_dns_a_record_set.go
+++ b/dns/resource_dns_a_record_set.go
@@ -68,6 +68,7 @@ func resourceDnsARecordSetRead(d *schema.ResourceData, meta interface{}) error {
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
+	Retry:
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypeA)
 
@@ -76,6 +77,8 @@ func resourceDnsARecordSetRead(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
 		switch r.Rcode {
+		case dns.RcodeServerFailure:
+			goto Retry
 		case dns.RcodeSuccess:
 			break
 		case dns.RcodeNameError:

--- a/dns/resource_dns_aaaa_record_set.go
+++ b/dns/resource_dns_aaaa_record_set.go
@@ -68,6 +68,7 @@ func resourceDnsAAAARecordSetRead(d *schema.ResourceData, meta interface{}) erro
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
+	Retry:
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypeAAAA)
 
@@ -76,6 +77,8 @@ func resourceDnsAAAARecordSetRead(d *schema.ResourceData, meta interface{}) erro
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
 		switch r.Rcode {
+		case dns.RcodeServerFailure:
+			goto Retry
 		case dns.RcodeSuccess:
 			break
 		case dns.RcodeNameError:

--- a/dns/resource_dns_cname_record.go
+++ b/dns/resource_dns_cname_record.go
@@ -66,6 +66,7 @@ func resourceDnsCnameRecordRead(d *schema.ResourceData, meta interface{}) error 
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
+	Retry:
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypeCNAME)
 
@@ -74,6 +75,8 @@ func resourceDnsCnameRecordRead(d *schema.ResourceData, meta interface{}) error 
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
 		switch r.Rcode {
+		case dns.RcodeServerFailure:
+			goto Retry
 		case dns.RcodeSuccess:
 			break
 		case dns.RcodeNameError:

--- a/dns/resource_dns_ns_record_set.go
+++ b/dns/resource_dns_ns_record_set.go
@@ -71,6 +71,7 @@ func resourceDnsNSRecordSetRead(d *schema.ResourceData, meta interface{}) error 
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
+	Retry:
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypeNS)
 
@@ -79,6 +80,8 @@ func resourceDnsNSRecordSetRead(d *schema.ResourceData, meta interface{}) error 
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
 		switch r.Rcode {
+		case dns.RcodeServerFailure:
+			goto Retry
 		case dns.RcodeSuccess:
 			break
 		case dns.RcodeNameError:

--- a/dns/resource_dns_ptr_record.go
+++ b/dns/resource_dns_ptr_record.go
@@ -66,6 +66,7 @@ func resourceDnsPtrRecordRead(d *schema.ResourceData, meta interface{}) error {
 
 		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
 
+	Retry:
 		msg := new(dns.Msg)
 		msg.SetQuestion(rec_fqdn, dns.TypePTR)
 
@@ -74,6 +75,8 @@ func resourceDnsPtrRecordRead(d *schema.ResourceData, meta interface{}) error {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
 		switch r.Rcode {
+		case dns.RcodeServerFailure:
+			goto Retry
 		case dns.RcodeSuccess:
 			break
 		case dns.RcodeNameError:


### PR DESCRIPTION
I was running into https://github.com/terraform-providers/terraform-provider-dns/issues/63 as well, but not with a server in china. I can now blast `-parallelism=100` with these changes.

After some digging, it turned out the real error was `SERVFAIL`, and simply retrying the connection would make it work every time. The retry currently would not retry opening a new connection, but instead try to make it work with the current connection resulting in the `i/o timeout`. Retrying the connection entirely when the `SERVFAIL` happens fixes a lot of issues. I worry that this change may introduce a loop when the DNS server fails forever, and wonder if we should add some kind of timeout for the `goto Retry` functions we have, but that feels like a wider discussion.