### PR TITLE
Allow creating apex records

### DIFF
--- a/dns/provider.go
+++ b/dns/provider.go
@@ -341,10 +341,10 @@ Loop:
 		return nil, fmt.Errorf("DNS record %s shares no common labels with zone %s", record, *zone)
 	}
 
-	name := strings.Join(labels[:len(labels)-common], ".")
-
-	d.Set("name", name)
 	d.Set("zone", *zone)
+	if name := strings.Join(labels[:len(labels)-common], "."); name != "" {
+		d.Set("name", name)
+	}
 
 	return []*schema.ResourceData{d}, nil
 }

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -328,7 +328,7 @@ Loop:
 		case dns.RcodeNameError:
 			continue
 		default:
-			return nil, fmt.Errorf("Error querying DNS record: %s", dns.RcodeToString[r.Rcode])
+			return nil, fmt.Errorf("Error querying DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
 		}
 	}
 

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -348,3 +348,14 @@ Loop:
 
 	return []*schema.ResourceData{d}, nil
 }
+
+func resourceFQDN(d *schema.ResourceData) string {
+
+	fqdn := d.Get("zone").(string)
+
+	if name, ok := d.GetOk("name"); ok {
+		fqdn = fmt.Sprintf("%s.%s", name.(string), fqdn)
+	}
+
+	return fqdn
+}

--- a/dns/provider_test.go
+++ b/dns/provider_test.go
@@ -1,6 +1,7 @@
 package dns
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -33,4 +34,13 @@ func testAccPreCheck(t *testing.T) {
 	if v == "" {
 		t.Fatal("DNS_UPDATE_SERVER must be set for acceptance tests")
 	}
+}
+
+func testResourceFQDN(name, zone string) string {
+	fqdn := zone
+	if name != "" {
+		fqdn = fmt.Sprintf("%s.%s", name, fqdn)
+	}
+
+	return fqdn
 }

--- a/dns/provider_test.go
+++ b/dns/provider_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/terraform"
+	"github.com/miekg/dns"
 )
 
 var testAccProviders map[string]terraform.ResourceProvider
@@ -43,4 +44,29 @@ func testResourceFQDN(name, zone string) string {
 	}
 
 	return fqdn
+}
+
+func testAccCheckDnsDestroy(s *terraform.State, resourceType string, rrType uint16) error {
+	meta := testAccProvider.Meta()
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != resourceType {
+			continue
+		}
+
+		fqdn := testResourceFQDN(rs.Primary.Attributes["name"], rs.Primary.Attributes["zone"])
+
+		msg := new(dns.Msg)
+		msg.SetQuestion(fqdn, rrType)
+		r, err := exchange(msg, false, meta)
+		if err != nil {
+			return fmt.Errorf("Error querying DNS record: %s", err)
+		}
+		// Should either get an NXDOMAIN or a NOERROR and no answers
+		// (and usually an authority record)
+		if !(r.Rcode == dns.RcodeNameError || (r.Rcode == dns.RcodeSuccess && ((rrType == dns.TypeNS && len(r.Ns) == 0) || len(r.Answer) == 0))) {
+			return fmt.Errorf("DNS record still exists: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
+		}
+	}
+
+	return nil
 }

--- a/dns/resource_dns_a_record_set.go
+++ b/dns/resource_dns_a_record_set.go
@@ -123,8 +123,6 @@ func resourceDnsARecordSetUpdate(d *schema.ResourceData, meta interface{}) error
 				d.SetId("")
 				return fmt.Errorf("Error updating DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
 			}
-
-			d.Set("addresses", ns)
 		}
 
 		return resourceDnsARecordSetRead(d, meta)

--- a/dns/resource_dns_a_record_set.go
+++ b/dns/resource_dns_a_record_set.go
@@ -27,7 +27,7 @@ func resourceDnsARecordSet() *schema.Resource {
 			},
 			"name": &schema.Schema{
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateName,
 			},
@@ -49,46 +49,24 @@ func resourceDnsARecordSet() *schema.Resource {
 
 func resourceDnsARecordSetCreate(d *schema.ResourceData, meta interface{}) error {
 
-	rec_name := d.Get("name").(string)
-	rec_zone := d.Get("zone").(string)
-
-	rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
-
-	d.SetId(rec_fqdn)
+	d.SetId(resourceFQDN(d))
 
 	return resourceDnsARecordSetUpdate(d, meta)
 }
 
 func resourceDnsARecordSetRead(d *schema.ResourceData, meta interface{}) error {
 
-	if meta != nil {
+	answers, err := resourceDnsRead(d, meta, dns.TypeA)
+	if err != nil {
+		return err
+	}
 
-		rec_name := d.Get("name").(string)
-		rec_zone := d.Get("zone").(string)
-
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
-
-		msg := new(dns.Msg)
-		msg.SetQuestion(rec_fqdn, dns.TypeA)
-
-		r, err := exchange(msg, true, meta)
-		if err != nil {
-			return fmt.Errorf("Error querying DNS record: %s", err)
-		}
-		switch r.Rcode {
-		case dns.RcodeSuccess:
-			break
-		case dns.RcodeNameError:
-			d.SetId("")
-			return nil
-		default:
-			return fmt.Errorf("Error querying DNS record: %s", dns.RcodeToString[r.Rcode])
-		}
+	if len(answers) > 0 {
 
 		var ttl sort.IntSlice
 
 		addresses := schema.NewSet(hashIPString, nil)
-		for _, record := range r.Answer {
+		for _, record := range answers {
 			addr, t, err := getAVal(record)
 			if err != nil {
 				return fmt.Errorf("Error querying DNS record: %s", err)
@@ -98,30 +76,25 @@ func resourceDnsARecordSetRead(d *schema.ResourceData, meta interface{}) error {
 		}
 		sort.Sort(ttl)
 
-		d.Set("name", rec_name)
-		d.Set("zone", rec_zone)
 		d.Set("addresses", addresses)
 		d.Set("ttl", ttl[0])
-
-		return nil
 	} else {
-		return fmt.Errorf("update server is not set")
+		d.SetId("")
 	}
+
+	return nil
 }
 
 func resourceDnsARecordSetUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if meta != nil {
 
-		rec_name := d.Get("name").(string)
-		rec_zone := d.Get("zone").(string)
 		ttl := d.Get("ttl").(int)
-
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
+		rec_fqdn := resourceFQDN(d)
 
 		msg := new(dns.Msg)
 
-		msg.SetUpdate(rec_zone)
+		msg.SetUpdate(d.Get("zone").(string))
 
 		if d.HasChange("addresses") {
 			o, n := d.GetChange("addresses")
@@ -151,8 +124,7 @@ func resourceDnsARecordSetUpdate(d *schema.ResourceData, meta interface{}) error
 				return fmt.Errorf("Error updating DNS record: %v", r.Rcode)
 			}
 
-			addresses := ns
-			d.Set("addresses", addresses)
+			d.Set("addresses", ns)
 		}
 
 		return resourceDnsARecordSetRead(d, meta)
@@ -163,30 +135,5 @@ func resourceDnsARecordSetUpdate(d *schema.ResourceData, meta interface{}) error
 
 func resourceDnsARecordSetDelete(d *schema.ResourceData, meta interface{}) error {
 
-	if meta != nil {
-
-		rec_name := d.Get("name").(string)
-		rec_zone := d.Get("zone").(string)
-
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
-
-		msg := new(dns.Msg)
-
-		msg.SetUpdate(rec_zone)
-
-		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 A", rec_fqdn))
-		msg.RemoveRRset([]dns.RR{rr_remove})
-
-		r, err := exchange(msg, true, meta)
-		if err != nil {
-			return fmt.Errorf("Error deleting DNS record: %s", err)
-		}
-		if r.Rcode != dns.RcodeSuccess {
-			return fmt.Errorf("Error deleting DNS record: %v", r.Rcode)
-		}
-
-		return nil
-	} else {
-		return fmt.Errorf("update server is not set")
-	}
+	return resourceDnsDelete(d, meta, dns.TypeA)
 }

--- a/dns/resource_dns_a_record_set.go
+++ b/dns/resource_dns_a_record_set.go
@@ -121,7 +121,7 @@ func resourceDnsARecordSetUpdate(d *schema.ResourceData, meta interface{}) error
 			}
 			if r.Rcode != dns.RcodeSuccess {
 				d.SetId("")
-				return fmt.Errorf("Error updating DNS record: %v", r.Rcode)
+				return fmt.Errorf("Error updating DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
 			}
 
 			d.Set("addresses", ns)

--- a/dns/resource_dns_aaaa_record_set.go
+++ b/dns/resource_dns_aaaa_record_set.go
@@ -27,7 +27,7 @@ func resourceDnsAAAARecordSet() *schema.Resource {
 			},
 			"name": &schema.Schema{
 				Type:         schema.TypeString,
-				Required:     true,
+				Optional:     true,
 				ForceNew:     true,
 				ValidateFunc: validateName,
 			},
@@ -49,46 +49,24 @@ func resourceDnsAAAARecordSet() *schema.Resource {
 
 func resourceDnsAAAARecordSetCreate(d *schema.ResourceData, meta interface{}) error {
 
-	rec_name := d.Get("name").(string)
-	rec_zone := d.Get("zone").(string)
-
-	rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
-
-	d.SetId(rec_fqdn)
+	d.SetId(resourceFQDN(d))
 
 	return resourceDnsAAAARecordSetUpdate(d, meta)
 }
 
 func resourceDnsAAAARecordSetRead(d *schema.ResourceData, meta interface{}) error {
 
-	if meta != nil {
+	answers, err := resourceDnsRead(d, meta, dns.TypeAAAA)
+	if err != nil {
+		return err
+	}
 
-		rec_name := d.Get("name").(string)
-		rec_zone := d.Get("zone").(string)
-
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
-
-		msg := new(dns.Msg)
-		msg.SetQuestion(rec_fqdn, dns.TypeAAAA)
-
-		r, err := exchange(msg, true, meta)
-		if err != nil {
-			return fmt.Errorf("Error querying DNS record: %s", err)
-		}
-		switch r.Rcode {
-		case dns.RcodeSuccess:
-			break
-		case dns.RcodeNameError:
-			d.SetId("")
-			return nil
-		default:
-			return fmt.Errorf("Error querying DNS record: %s", dns.RcodeToString[r.Rcode])
-		}
+	if len(answers) > 0 {
 
 		var ttl sort.IntSlice
 
 		addresses := schema.NewSet(hashIPString, nil)
-		for _, record := range r.Answer {
+		for _, record := range answers {
 			addr, t, err := getAAAAVal(record)
 			if err != nil {
 				return fmt.Errorf("Error querying DNS record: %s", err)
@@ -98,30 +76,26 @@ func resourceDnsAAAARecordSetRead(d *schema.ResourceData, meta interface{}) erro
 		}
 		sort.Sort(ttl)
 
-		d.Set("name", rec_name)
-		d.Set("zone", rec_zone)
 		d.Set("addresses", addresses)
 		d.Set("ttl", ttl[0])
-
-		return nil
 	} else {
-		return fmt.Errorf("update server is not set")
+		d.SetId("")
 	}
+
+	return nil
 }
 
 func resourceDnsAAAARecordSetUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if meta != nil {
 
-		rec_name := d.Get("name").(string)
-		rec_zone := d.Get("zone").(string)
 		ttl := d.Get("ttl").(int)
 
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
+		rec_fqdn := resourceFQDN(d)
 
 		msg := new(dns.Msg)
 
-		msg.SetUpdate(rec_zone)
+		msg.SetUpdate(d.Get("zone").(string))
 
 		if d.HasChange("addresses") {
 			o, n := d.GetChange("addresses")
@@ -151,8 +125,7 @@ func resourceDnsAAAARecordSetUpdate(d *schema.ResourceData, meta interface{}) er
 				return fmt.Errorf("Error updating DNS record: %v", r.Rcode)
 			}
 
-			addresses := ns
-			d.Set("addresses", addresses)
+			d.Set("addresses", ns)
 		}
 
 		return resourceDnsAAAARecordSetRead(d, meta)
@@ -163,30 +136,5 @@ func resourceDnsAAAARecordSetUpdate(d *schema.ResourceData, meta interface{}) er
 
 func resourceDnsAAAARecordSetDelete(d *schema.ResourceData, meta interface{}) error {
 
-	if meta != nil {
-
-		rec_name := d.Get("name").(string)
-		rec_zone := d.Get("zone").(string)
-
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
-
-		msg := new(dns.Msg)
-
-		msg.SetUpdate(rec_zone)
-
-		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 AAAA", rec_fqdn))
-		msg.RemoveRRset([]dns.RR{rr_remove})
-
-		r, err := exchange(msg, true, meta)
-		if err != nil {
-			return fmt.Errorf("Error deleting DNS record: %s", err)
-		}
-		if r.Rcode != dns.RcodeSuccess {
-			return fmt.Errorf("Error deleting DNS record: %v", r.Rcode)
-		}
-
-		return nil
-	} else {
-		return fmt.Errorf("update server is not set")
-	}
+	return resourceDnsDelete(d, meta, dns.TypeAAAA)
 }

--- a/dns/resource_dns_aaaa_record_set.go
+++ b/dns/resource_dns_aaaa_record_set.go
@@ -124,8 +124,6 @@ func resourceDnsAAAARecordSetUpdate(d *schema.ResourceData, meta interface{}) er
 				d.SetId("")
 				return fmt.Errorf("Error updating DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
 			}
-
-			d.Set("addresses", ns)
 		}
 
 		return resourceDnsAAAARecordSetRead(d, meta)

--- a/dns/resource_dns_aaaa_record_set.go
+++ b/dns/resource_dns_aaaa_record_set.go
@@ -122,7 +122,7 @@ func resourceDnsAAAARecordSetUpdate(d *schema.ResourceData, meta interface{}) er
 			}
 			if r.Rcode != dns.RcodeSuccess {
 				d.SetId("")
-				return fmt.Errorf("Error updating DNS record: %v", r.Rcode)
+				return fmt.Errorf("Error updating DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
 			}
 
 			d.Set("addresses", ns)

--- a/dns/resource_dns_cname_record.go
+++ b/dns/resource_dns_cname_record.go
@@ -109,7 +109,7 @@ func resourceDnsCnameRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 			}
 			if r.Rcode != dns.RcodeSuccess {
 				d.SetId("")
-				return fmt.Errorf("Error updating DNS record: %v", r.Rcode)
+				return fmt.Errorf("Error updating DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
 			}
 
 			d.Set("cname", n)

--- a/dns/resource_dns_cname_record.go
+++ b/dns/resource_dns_cname_record.go
@@ -47,74 +47,48 @@ func resourceDnsCnameRecord() *schema.Resource {
 
 func resourceDnsCnameRecordCreate(d *schema.ResourceData, meta interface{}) error {
 
-	rec_name := d.Get("name").(string)
-	rec_zone := d.Get("zone").(string)
-
-	rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
-
-	d.SetId(rec_fqdn)
+	d.SetId(resourceFQDN(d))
 
 	return resourceDnsCnameRecordUpdate(d, meta)
 }
 
 func resourceDnsCnameRecordRead(d *schema.ResourceData, meta interface{}) error {
 
-	if meta != nil {
+	answers, err := resourceDnsRead(d, meta, dns.TypeCNAME)
+	if err != nil {
+		return err
+	}
 
-		rec_name := d.Get("name").(string)
-		rec_zone := d.Get("zone").(string)
+	if len(answers) > 0 {
 
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
-
-		msg := new(dns.Msg)
-		msg.SetQuestion(rec_fqdn, dns.TypeCNAME)
-
-		r, err := exchange(msg, true, meta)
-		if err != nil {
-			return fmt.Errorf("Error querying DNS record: %s", err)
-		}
-		switch r.Rcode {
-		case dns.RcodeSuccess:
-			break
-		case dns.RcodeNameError:
-			d.SetId("")
-			return nil
-		default:
-			return fmt.Errorf("Error querying DNS record: %s", dns.RcodeToString[r.Rcode])
-		}
-
-		if len(r.Answer) > 1 {
+		if len(answers) > 1 {
 			return fmt.Errorf("Error querying DNS record: multiple responses received")
 		}
-		record := r.Answer[0]
+		record := answers[0]
 		cname, ttl, err := getCnameVal(record)
 		if err != nil {
 			return fmt.Errorf("Error querying DNS record: %s", err)
 		}
-		d.Set("name", rec_name)
-		d.Set("zone", rec_zone)
 		d.Set("cname", cname)
 		d.Set("ttl", ttl)
-
-		return nil
 	} else {
-		return fmt.Errorf("update server is not set")
+		d.SetId("")
 	}
+
+	return nil
 }
 
 func resourceDnsCnameRecordUpdate(d *schema.ResourceData, meta interface{}) error {
 
 	if meta != nil {
 
-		rec_name := d.Get("name").(string)
-		rec_zone := d.Get("zone").(string)
 		ttl := d.Get("ttl").(int)
 
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
+		rec_fqdn := resourceFQDN(d)
 
 		msg := new(dns.Msg)
 
-		msg.SetUpdate(rec_zone)
+		msg.SetUpdate(d.Get("zone").(string))
 
 		if d.HasChange("cname") {
 			o, n := d.GetChange("cname")
@@ -138,8 +112,7 @@ func resourceDnsCnameRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 				return fmt.Errorf("Error updating DNS record: %v", r.Rcode)
 			}
 
-			cname := n
-			d.Set("cname", cname)
+			d.Set("cname", n)
 		}
 
 		return resourceDnsCnameRecordRead(d, meta)
@@ -150,30 +123,5 @@ func resourceDnsCnameRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 
 func resourceDnsCnameRecordDelete(d *schema.ResourceData, meta interface{}) error {
 
-	if meta != nil {
-
-		rec_name := d.Get("name").(string)
-		rec_zone := d.Get("zone").(string)
-
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
-
-		msg := new(dns.Msg)
-
-		msg.SetUpdate(rec_zone)
-
-		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 CNAME", rec_fqdn))
-		msg.RemoveRRset([]dns.RR{rr_remove})
-
-		r, err := exchange(msg, true, meta)
-		if err != nil {
-			return fmt.Errorf("Error deleting DNS record: %s", err)
-		}
-		if r.Rcode != dns.RcodeSuccess {
-			return fmt.Errorf("Error deleting DNS record: %v", r.Rcode)
-		}
-
-		return nil
-	} else {
-		return fmt.Errorf("update server is not set")
-	}
+	return resourceDnsDelete(d, meta, dns.TypeCNAME)
 }

--- a/dns/resource_dns_cname_record.go
+++ b/dns/resource_dns_cname_record.go
@@ -111,8 +111,6 @@ func resourceDnsCnameRecordUpdate(d *schema.ResourceData, meta interface{}) erro
 				d.SetId("")
 				return fmt.Errorf("Error updating DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
 			}
-
-			d.Set("cname", n)
 		}
 
 		return resourceDnsCnameRecordRead(d, meta)

--- a/dns/resource_dns_cname_record_test.go
+++ b/dns/resource_dns_cname_record_test.go
@@ -21,7 +21,7 @@ func TestAccDnsCnameRecord_basic(t *testing.T) {
 
 		msg.SetUpdate(rec_zone)
 
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
+		rec_fqdn := testResourceFQDN(rec_name, rec_zone)
 
 		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 CNAME", rec_fqdn))
 		msg.RemoveRRset([]dns.RR{rr_remove})
@@ -69,29 +69,7 @@ func TestAccDnsCnameRecord_basic(t *testing.T) {
 }
 
 func testAccCheckDnsCnameRecordDestroy(s *terraform.State) error {
-	meta := testAccProvider.Meta()
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "dns_cname_record" {
-			continue
-		}
-
-		rec_name := rs.Primary.Attributes["name"]
-		rec_zone := rs.Primary.Attributes["zone"]
-
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
-
-		msg := new(dns.Msg)
-		msg.SetQuestion(rec_fqdn, dns.TypeCNAME)
-		r, err := exchange(msg, false, meta)
-		if err != nil {
-			return fmt.Errorf("Error querying DNS record: %s", err)
-		}
-		if r.Rcode != dns.RcodeNameError {
-			return fmt.Errorf("DNS record still exists: %v", r.Rcode)
-		}
-	}
-
-	return nil
+	return testAccCheckDnsDestroy(s, "dns_cname_record", dns.TypeCNAME)
 }
 
 func testAccCheckDnsCnameRecordExists(t *testing.T, n string, expected string, rec_name, rec_zone *string) resource.TestCheckFunc {
@@ -107,7 +85,7 @@ func testAccCheckDnsCnameRecordExists(t *testing.T, n string, expected string, r
 		*rec_name = rs.Primary.Attributes["name"]
 		*rec_zone = rs.Primary.Attributes["zone"]
 
-		rec_fqdn := fmt.Sprintf("%s.%s", *rec_name, *rec_zone)
+		rec_fqdn := testResourceFQDN(*rec_name, *rec_zone)
 
 		meta := testAccProvider.Meta()
 

--- a/dns/resource_dns_ns_record_set.go
+++ b/dns/resource_dns_ns_record_set.go
@@ -126,7 +126,7 @@ func resourceDnsNSRecordSetUpdate(d *schema.ResourceData, meta interface{}) erro
 			}
 			if r.Rcode != dns.RcodeSuccess {
 				d.SetId("")
-				return fmt.Errorf("Error updating DNS record: %v", r.Rcode)
+				return fmt.Errorf("Error updating DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
 			}
 
 			d.Set("nameservers", ns)

--- a/dns/resource_dns_ns_record_set.go
+++ b/dns/resource_dns_ns_record_set.go
@@ -128,8 +128,6 @@ func resourceDnsNSRecordSetUpdate(d *schema.ResourceData, meta interface{}) erro
 				d.SetId("")
 				return fmt.Errorf("Error updating DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
 			}
-
-			d.Set("nameservers", ns)
 		}
 
 		return resourceDnsNSRecordSetRead(d, meta)

--- a/dns/resource_dns_ns_record_set_test.go
+++ b/dns/resource_dns_ns_record_set_test.go
@@ -22,7 +22,7 @@ func TestAccDnsNSRecordSet_Basic(t *testing.T) {
 
 		msg.SetUpdate(rec_zone)
 
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
+		rec_fqdn := testResourceFQDN(rec_name, rec_zone)
 
 		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 NS", rec_fqdn))
 		msg.RemoveRRset([]dns.RR{rr_remove})
@@ -73,30 +73,7 @@ func TestAccDnsNSRecordSet_Basic(t *testing.T) {
 }
 
 func testAccCheckDnsNSRecordSetDestroy(s *terraform.State) error {
-	meta := testAccProvider.Meta()
-	for _, rs := range s.RootModule().Resources {
-		if rs.Type != "dns_ns_record_set" {
-			continue
-		}
-
-		rec_name := rs.Primary.Attributes["name"]
-		rec_zone := rs.Primary.Attributes["zone"]
-
-		rec_fqdn := fmt.Sprintf("%s.%s", rec_name, rec_zone)
-
-		msg := new(dns.Msg)
-		msg.SetQuestion(rec_fqdn, dns.TypeNS)
-
-		r, err := exchange(msg, false, meta)
-		if err != nil {
-			return fmt.Errorf("Error querying DNS record: %s", err)
-		}
-		if r.Rcode != dns.RcodeNameError {
-			return fmt.Errorf("DNS record still exists: %v", r.Rcode)
-		}
-	}
-
-	return nil
+	return testAccCheckDnsDestroy(s, "dns_ns_record_set", dns.TypeNS)
 }
 
 func testAccCheckDnsNSRecordSetExists(t *testing.T, n string, nameserver []interface{}, rec_name, rec_zone *string) resource.TestCheckFunc {
@@ -112,7 +89,7 @@ func testAccCheckDnsNSRecordSetExists(t *testing.T, n string, nameserver []inter
 		*rec_name = rs.Primary.Attributes["name"]
 		*rec_zone = rs.Primary.Attributes["zone"]
 
-		rec_fqdn := fmt.Sprintf("%s.%s", *rec_name, *rec_zone)
+		rec_fqdn := testResourceFQDN(*rec_name, *rec_zone)
 
 		meta := testAccProvider.Meta()
 

--- a/dns/resource_dns_ptr_record.go
+++ b/dns/resource_dns_ptr_record.go
@@ -111,8 +111,6 @@ func resourceDnsPtrRecordUpdate(d *schema.ResourceData, meta interface{}) error 
 				d.SetId("")
 				return fmt.Errorf("Error updating DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
 			}
-
-			d.Set("ptr", n)
 		}
 
 		return resourceDnsPtrRecordRead(d, meta)

--- a/dns/resource_dns_ptr_record.go
+++ b/dns/resource_dns_ptr_record.go
@@ -109,7 +109,7 @@ func resourceDnsPtrRecordUpdate(d *schema.ResourceData, meta interface{}) error 
 			}
 			if r.Rcode != dns.RcodeSuccess {
 				d.SetId("")
-				return fmt.Errorf("Error updating DNS record: %v", r.Rcode)
+				return fmt.Errorf("Error updating DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
 			}
 
 			d.Set("ptr", n)

--- a/dns/validators.go
+++ b/dns/validators.go
@@ -2,12 +2,16 @@ package dns
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/miekg/dns"
 )
 
 func validateZone(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
+	if strings.TrimSpace(value) != value {
+		errors = append(errors, fmt.Errorf("DNS zone name %q must not contain whitespace: %q", k, value))
+	}
 	if !dns.IsFqdn(value) {
 		errors = append(errors, fmt.Errorf("DNS zone name %q must be fully qualified: %q", k, value))
 	}
@@ -16,6 +20,9 @@ func validateZone(v interface{}, k string) (ws []string, errors []error) {
 
 func validateName(v interface{}, k string) (ws []string, errors []error) {
 	value := v.(string)
+	if strings.TrimSpace(value) != value || len(value) == 0 {
+		errors = append(errors, fmt.Errorf("DNS record name %q must not contain whitespace or be empty: %q", k, value))
+	}
 	if dns.IsFqdn(value) {
 		errors = append(errors, fmt.Errorf("DNS record name %q must not be fully qualified: %q", k, value))
 	}

--- a/dns/validators_test.go
+++ b/dns/validators_test.go
@@ -17,6 +17,9 @@ func TestValidateZone(t *testing.T) {
 
 	invalidNames := []string{
 		"example.com",
+		" example.com.",
+		" ",
+		"",
 	}
 	for _, v := range invalidNames {
 		_, errors := validateZone(v, "name")
@@ -39,6 +42,9 @@ func TestValidateName(t *testing.T) {
 
 	invalidNames := []string{
 		"test.",
+		" test. ",
+		" ",
+		"",
 	}
 	for _, v := range invalidNames {
 		_, errors := validateName(v, "name")

--- a/website/docs/r/dns_a_record_set.html.markdown
+++ b/website/docs/r/dns_a_record_set.html.markdown
@@ -30,7 +30,7 @@ resource "dns_a_record_set" "www" {
 The following arguments are supported:
 
 * `zone` - (Required) DNS zone the record set belongs to. It must be an FQDN, that is, include the trailing dot.
-* `name` - (Required) The name of the record set. The `zone` argument will be appended to this value to create the full record path.
+* `name` - (Optional) The name of the record set. The `zone` argument will be appended to this value to create the full record path.
 * `addresses` - (Required) The IPv4 addresses this record set will point to.
 * `ttl` - (Optional) The TTL of the record set. Defaults to `3600`.
 

--- a/website/docs/r/dns_aaaa_record_set.html.markdown
+++ b/website/docs/r/dns_aaaa_record_set.html.markdown
@@ -29,7 +29,7 @@ resource "dns_aaaa_record_set" "www" {
 The following arguments are supported:
 
 * `zone` - (Required) DNS zone the record set belongs to. It must be an FQDN, that is, include the trailing dot.
-* `name` - (Required) The name of the record set. The `zone` argument will be appended to this value to create the full record path.
+* `name` - (Optional) The name of the record set. The `zone` argument will be appended to this value to create the full record path.
 * `addresses` - (Required) The IPv6 addresses this record set will point to.
 * `ttl` - (Optional) The TTL of the record set. Defaults to `3600`.
 

--- a/website/docs/r/dns_ptr_record.html.markdown
+++ b/website/docs/r/dns_ptr_record.html.markdown
@@ -26,7 +26,7 @@ resource "dns_ptr_record" "dns-sd" {
 The following arguments are supported:
 
 * `zone` - (Required) DNS zone the record belongs to. It must be an FQDN, that is, include the trailing dot.
-* `name` - (Required) The name of the record. The `zone` argument will be appended to this value to create the full record path.
+* `name` - (Optional) The name of the record. The `zone` argument will be appended to this value to create the full record path.
 * `ptr` - (Required) The canonical name this record will point to.
 * `ttl` - (Optional) The TTL of the record set. Defaults to `3600`.
 


### PR DESCRIPTION
Currently it's not possible to create apex records or naked domains, i.e. `example.com`. This is because both the `name` and `zone` arguments are required on all resources.

This PR updates the `A`, `AAAA`, & `PTR` resources to make the `name` argument optional. `CNAME` is not changed as it's illegal to create one as an apex record. `NS` is also not currently updated because it cannot be deleted properly, (BIND at least will refuse to delete all `SOA` and `NS` apex records from a zone which may create erroring Terraform runs), 

These records can still be imported.

I've done a fair bit of refactoring here to reduce the amount of duplicated code and I've also fixed what is possibly a lurking bug that if you have existing record(s) for the same FQDN and manage a new record, you won't get `NXDOMAIN` returned anymore, you  get `NOERROR` and an empty answer.

Fixes #48