### PR TITLE
SRV record resource and datasource

### DIFF
--- a/dns/data_dns_a_record_set_test.go
+++ b/dns/data_dns_a_record_set_test.go
@@ -43,7 +43,7 @@ func TestAccDataDnsARecordSet_Basic(t *testing.T) {
 	for _, test := range tests {
 		recordName := fmt.Sprintf("data.dns_a_record_set.%s", test.DataSourceName)
 
-		resource.Test(t, resource.TestCase{
+		resource.UnitTest(t, resource.TestCase{
 			Providers: testAccProviders,
 			Steps: []resource.TestStep{
 				{

--- a/dns/data_dns_aaaa_record_set_test.go
+++ b/dns/data_dns_aaaa_record_set_test.go
@@ -31,7 +31,7 @@ func TestAccDataDnsAAAARecordSet_Basic(t *testing.T) {
 	for _, test := range tests {
 		recordName := fmt.Sprintf("data.dns_aaaa_record_set.%s", test.DataSourceName)
 
-		resource.Test(t, resource.TestCase{
+		resource.UnitTest(t, resource.TestCase{
 			Providers: testAccProviders,
 			Steps: []resource.TestStep{
 				{

--- a/dns/data_dns_cname_record_set_test.go
+++ b/dns/data_dns_cname_record_set_test.go
@@ -24,7 +24,7 @@ func TestAccDataDnsCnameRecordSet_Basic(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		resource.Test(t, resource.TestCase{
+		resource.UnitTest(t, resource.TestCase{
 			Providers: testAccProviders,
 			Steps: []resource.TestStep{
 				{

--- a/dns/data_dns_mx_record_set_test.go
+++ b/dns/data_dns_mx_record_set_test.go
@@ -38,7 +38,7 @@ func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
 	for _, test := range tests {
 		recordName := fmt.Sprintf("data.dns_mx_record_set.%s", test.DataSourceName)
 
-		resource.Test(t, resource.TestCase{
+		resource.UnitTest(t, resource.TestCase{
 			Providers: testAccProviders,
 			Steps: []resource.TestStep{
 				{

--- a/dns/data_dns_ns_record_set_test.go
+++ b/dns/data_dns_ns_record_set_test.go
@@ -35,7 +35,7 @@ func TestAccDataDnsNSRecordSet_Basic(t *testing.T) {
 	for _, test := range tests {
 		recordName := fmt.Sprintf("data.dns_ns_record_set.%s", test.DataSourceName)
 
-		resource.Test(t, resource.TestCase{
+		resource.UnitTest(t, resource.TestCase{
 			Providers: testAccProviders,
 			Steps: []resource.TestStep{
 				{

--- a/dns/data_dns_ptr_record_set_test.go
+++ b/dns/data_dns_ptr_record_set_test.go
@@ -24,7 +24,7 @@ func TestAccDataDnsPtrRecordSet_Basic(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		resource.Test(t, resource.TestCase{
+		resource.UnitTest(t, resource.TestCase{
 			Providers: testAccProviders,
 			Steps: []resource.TestStep{
 				{

--- a/dns/data_dns_srv_record_set.go
+++ b/dns/data_dns_srv_record_set.go
@@ -1,0 +1,96 @@
+package dns
+
+import (
+	"fmt"
+	"net"
+	"sort"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceDnsSRVRecordSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDnsSRVRecordSetRead,
+		Schema: map[string]*schema.Schema{
+			"service": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"srv": &schema.Schema{
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"priority": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"weight": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"target": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDnsSRVRecordSetRead(d *schema.ResourceData, meta interface{}) error {
+	service := d.Get("service").(string)
+
+	_, records, err := net.LookupSRV("", "", service)
+	if err != nil {
+		return fmt.Errorf("error looking up SRV records for %q: %s", service, err)
+	}
+
+	// Sort by priority ascending, weight descending, target
+	// alphabetically, and port ascending
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].Priority < records[j].Priority {
+			return true
+		}
+		if records[i].Priority > records[j].Priority {
+			return false
+		}
+		if records[i].Weight > records[j].Weight {
+			return true
+		}
+		if records[i].Weight < records[j].Weight {
+			return false
+		}
+		if records[i].Target < records[j].Target {
+			return true
+		}
+		if records[i].Target > records[j].Target {
+			return false
+		}
+		return records[i].Port < records[j].Port
+	})
+
+	srv := make([]map[string]interface{}, len(records))
+	for i, record := range records {
+		srv[i] = map[string]interface{}{
+			"priority": int(record.Priority),
+			"weight":   int(record.Weight),
+			"port":     int(record.Port),
+			"target":   record.Target,
+		}
+	}
+
+	err = d.Set("srv", srv)
+	if err != nil {
+		return err
+	}
+	d.SetId(service)
+
+	return nil
+}

--- a/dns/data_dns_srv_record_set_test.go
+++ b/dns/data_dns_srv_record_set_test.go
@@ -1,0 +1,55 @@
+package dns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+)
+
+func TestAccDataDnsSRVRecordSet_Basic(t *testing.T) {
+	tests := []struct {
+		DataSourceBlock string
+		DataSourceName  string
+		Expected        []string
+		Host            string
+	}{
+		/* FIXME Need an online SRV record
+		{
+			`
+			data "dns_srv_record_set" "srv" {
+			  host = "example.com"
+			}
+			`,
+			"srv",
+			[]string{
+				"2606:2800:220:1:248:1893:25c8:1946",
+			},
+			"example.com",
+		},
+		*/
+	}
+
+	for _, test := range tests {
+		recordName := fmt.Sprintf("data.dns_srv_record_set.%s", test.DataSourceName)
+
+		resource.Test(t, resource.TestCase{
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						testCheckAttrStringArray(recordName, "srv", test.Expected),
+					),
+				},
+				{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(recordName, "id", test.Host),
+					),
+				},
+			},
+		})
+	}
+
+}

--- a/dns/data_dns_srv_record_set_test.go
+++ b/dns/data_dns_srv_record_set_test.go
@@ -21,7 +21,7 @@ func TestAccDataDnsSRVRecordSet_Basic(t *testing.T) {
 			}
 			`,
 			"srv",
-			"mxtoolbox.com",
+			"mxtoolbox.com.",
 			"_http._tcp.mxtoolbox.com",
 		},
 	}

--- a/dns/data_dns_srv_record_set_test.go
+++ b/dns/data_dns_srv_record_set_test.go
@@ -11,23 +11,19 @@ func TestAccDataDnsSRVRecordSet_Basic(t *testing.T) {
 	tests := []struct {
 		DataSourceBlock string
 		DataSourceName  string
-		Expected        []string
-		Host            string
+		ExpectedTarget  string
+		Service         string
 	}{
-		/* FIXME Need an online SRV record
 		{
 			`
 			data "dns_srv_record_set" "srv" {
-			  host = "example.com"
+			  service = "_http._tcp.mxtoolbox.com"
 			}
 			`,
 			"srv",
-			[]string{
-				"2606:2800:220:1:248:1893:25c8:1946",
-			},
-			"example.com",
+			"mxtoolbox.com",
+			"_http._tcp.mxtoolbox.com",
 		},
-		*/
 	}
 
 	for _, test := range tests {
@@ -39,13 +35,13 @@ func TestAccDataDnsSRVRecordSet_Basic(t *testing.T) {
 				{
 					Config: test.DataSourceBlock,
 					Check: resource.ComposeTestCheckFunc(
-						testCheckAttrStringArray(recordName, "srv", test.Expected),
+						resource.TestCheckResourceAttr(recordName, "srv.0.target", test.ExpectedTarget),
 					),
 				},
 				{
 					Config: test.DataSourceBlock,
 					Check: resource.ComposeTestCheckFunc(
-						resource.TestCheckResourceAttr(recordName, "id", test.Host),
+						resource.TestCheckResourceAttr(recordName, "id", test.Service),
 					),
 				},
 			},

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -102,6 +102,7 @@ func Provider() terraform.ResourceProvider {
 			"dns_mx_record_set":    dataSourceDnsMXRecordSet(),
 			"dns_ns_record_set":    dataSourceDnsNSRecordSet(),
 			"dns_ptr_record_set":   dataSourceDnsPtrRecordSet(),
+			"dns_srv_record_set":   dataSourceDnsSRVRecordSet(),
 			"dns_txt_record_set":   dataSourceDnsTxtRecordSet(),
 		},
 
@@ -112,6 +113,7 @@ func Provider() terraform.ResourceProvider {
 			"dns_mx_record_set":   resourceDnsMXRecordSet(),
 			"dns_ns_record_set":   resourceDnsNSRecordSet(),
 			"dns_ptr_record":      resourceDnsPtrRecord(),
+			"dns_srv_record_set":  resourceDnsSRVRecordSet(),
 			"dns_txt_record_set":  resourceDnsTXTRecordSet(),
 		},
 

--- a/dns/resource_dns_srv_record_set.go
+++ b/dns/resource_dns_srv_record_set.go
@@ -1,0 +1,179 @@
+package dns
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/miekg/dns"
+)
+
+func resourceDnsSRVRecordSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDnsSRVRecordSetCreate,
+		Read:   resourceDnsSRVRecordSetRead,
+		Update: resourceDnsSRVRecordSetUpdate,
+		Delete: resourceDnsSRVRecordSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDnsImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"zone": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateZone,
+			},
+			"name": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateName,
+			},
+			"srv": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"priority": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"weight": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"port": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"target": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateZone,
+						},
+					},
+				},
+				Set: resourceDnsSRVRecordSetHash,
+			},
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  3600,
+			},
+		},
+	}
+}
+
+func resourceDnsSRVRecordSetCreate(d *schema.ResourceData, meta interface{}) error {
+
+	d.SetId(resourceFQDN(d))
+
+	return resourceDnsSRVRecordSetUpdate(d, meta)
+}
+
+func resourceDnsSRVRecordSetRead(d *schema.ResourceData, meta interface{}) error {
+
+	answers, err := resourceDnsRead(d, meta, dns.TypeSRV)
+	if err != nil {
+		return err
+	}
+
+	if len(answers) > 0 {
+
+		var ttl sort.IntSlice
+
+		srv := schema.NewSet(resourceDnsSRVRecordSetHash, nil)
+		for _, record := range answers {
+			switch r := record.(type) {
+			case *dns.SRV:
+				s := map[string]interface{}{
+					"priority": int(r.Priority),
+					"weight":   int(r.Weight),
+					"port":     int(r.Port),
+					"target":   r.Target,
+				}
+				srv.Add(s)
+				ttl = append(ttl, int(r.Hdr.Ttl))
+			default:
+				return fmt.Errorf("didn't get an SRV record")
+			}
+		}
+		sort.Sort(ttl)
+
+		d.Set("srv", srv)
+		d.Set("ttl", ttl[0])
+	} else {
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceDnsSRVRecordSetUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	if meta != nil {
+
+		ttl := d.Get("ttl").(int)
+		fqdn := resourceFQDN(d)
+
+		msg := new(dns.Msg)
+
+		msg.SetUpdate(d.Get("zone").(string))
+
+		if d.HasChange("srv") {
+			o, n := d.GetChange("srv")
+			os := o.(*schema.Set)
+			ns := n.(*schema.Set)
+			remove := os.Difference(ns).List()
+			add := ns.Difference(os).List()
+
+			// Loop through all the old addresses and remove them
+			for _, srv := range remove {
+				s := srv.(map[string]interface{})
+				rr_remove, _ := dns.NewRR(fmt.Sprintf("%s %d SRV %d %d %d %s", fqdn, ttl, s["priority"], s["weight"], s["port"], s["target"]))
+				msg.Remove([]dns.RR{rr_remove})
+			}
+			// Loop through all the new addresses and insert them
+			for _, srv := range add {
+				s := srv.(map[string]interface{})
+				rr_insert, _ := dns.NewRR(fmt.Sprintf("%s %d SRV %d %d %d %s", fqdn, ttl, s["priority"], s["weight"], s["port"], s["target"]))
+				msg.Insert([]dns.RR{rr_insert})
+			}
+
+			r, err := exchange(msg, true, meta)
+			if err != nil {
+				d.SetId("")
+				return fmt.Errorf("Error updating DNS record: %s", err)
+			}
+			if r.Rcode != dns.RcodeSuccess {
+				d.SetId("")
+				return fmt.Errorf("Error updating DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
+			}
+		}
+
+		return resourceDnsSRVRecordSetRead(d, meta)
+	} else {
+		return fmt.Errorf("update server is not set")
+	}
+}
+
+func resourceDnsSRVRecordSetDelete(d *schema.ResourceData, meta interface{}) error {
+
+	return resourceDnsDelete(d, meta, dns.TypeSRV)
+}
+
+func resourceDnsSRVRecordSetHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%d-", m["priority"].(int)))
+	buf.WriteString(fmt.Sprintf("%d-", m["weight"].(int)))
+	buf.WriteString(fmt.Sprintf("%d-", m["port"].(int)))
+	buf.WriteString(fmt.Sprintf("%s-", m["target"].(string)))
+
+	return hashcode.String(buf.String())
+}

--- a/dns/resource_dns_srv_record_set_test.go
+++ b/dns/resource_dns_srv_record_set_test.go
@@ -1,0 +1,159 @@
+package dns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/miekg/dns"
+)
+
+func TestAccDnsSRVRecordSet_Basic(t *testing.T) {
+
+	var name, zone string
+	resourceName := "dns_srv_record_set.foo"
+
+	deleteSRVRecordSet := func() {
+		meta := testAccProvider.Meta()
+
+		msg := new(dns.Msg)
+
+		msg.SetUpdate(zone)
+
+		fqdn := testResourceFQDN(name, zone)
+
+		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 SRV", fqdn))
+		msg.RemoveRRset([]dns.RR{rr_remove})
+
+		r, err := exchange(msg, true, meta)
+		if err != nil {
+			t.Fatalf("Error deleting DNS record: %s", err)
+		}
+		if r.Rcode != dns.RcodeSuccess {
+			t.Fatalf("Error deleting DNS record: %v", r.Rcode)
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDnsSRVRecordSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsSRVRecordSet_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "srv.#", "1"),
+					testAccCheckDnsSRVRecordSetExists(t, resourceName, []interface{}{map[string]interface{}{"priority": 10, "weight": 60, "port": 5060, "target": "bigbox.example.com."}}, &name, &zone),
+				),
+			},
+			{
+				Config: testAccDnsSRVRecordSet_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "srv.#", "2"),
+					testAccCheckDnsSRVRecordSetExists(t, resourceName, []interface{}{map[string]interface{}{"priority": 10, "weight": 60, "port": 5060, "target": "bigbox.example.com."}, map[string]interface{}{"priority": 20, "weight": 0, "port": 5060, "target": "backupbox.example.com."}}, &name, &zone),
+				),
+			},
+			{
+				PreConfig: deleteSRVRecordSet,
+				Config:    testAccDnsSRVRecordSet_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "srv.#", "2"),
+					testAccCheckDnsSRVRecordSetExists(t, resourceName, []interface{}{map[string]interface{}{"priority": 10, "weight": 60, "port": 5060, "target": "bigbox.example.com."}, map[string]interface{}{"priority": 20, "weight": 0, "port": 5060, "target": "backupbox.example.com."}}, &name, &zone),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDnsSRVRecordSetDestroy(s *terraform.State) error {
+	return testAccCheckDnsDestroy(s, "dns_srv_record_set", dns.TypeSRV)
+}
+
+func testAccCheckDnsSRVRecordSetExists(t *testing.T, n string, srv []interface{}, name, zone *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		*name = rs.Primary.Attributes["name"]
+		*zone = rs.Primary.Attributes["zone"]
+
+		fqdn := testResourceFQDN(*name, *zone)
+
+		meta := testAccProvider.Meta()
+
+		msg := new(dns.Msg)
+		msg.SetQuestion(fqdn, dns.TypeSRV)
+		r, err := exchange(msg, false, meta)
+		if err != nil {
+			return fmt.Errorf("Error querying DNS record: %s", err)
+		}
+		if r.Rcode != dns.RcodeSuccess {
+			return fmt.Errorf("Error querying DNS record")
+		}
+
+		existing := schema.NewSet(resourceDnsSRVRecordSetHash, nil)
+		expected := schema.NewSet(resourceDnsSRVRecordSetHash, srv)
+		for _, record := range r.Answer {
+			switch r := record.(type) {
+			case *dns.SRV:
+				s := map[string]interface{}{
+					"priority": int(r.Priority),
+					"weight":   int(r.Weight),
+					"port":     int(r.Port),
+					"target":   r.Target,
+				}
+				existing.Add(s)
+			default:
+				return fmt.Errorf("didn't get an SRV record")
+			}
+		}
+		if !existing.Equal(expected) {
+			return fmt.Errorf("DNS record differs: expected %v, found %v", expected, existing)
+		}
+		return nil
+	}
+}
+
+var testAccDnsSRVRecordSet_basic = fmt.Sprintf(`
+  resource "dns_srv_record_set" "foo" {
+    zone = "example.com."
+    name = "_sip._tcp"
+    srv {
+      priority = 10
+      weight = 60
+      port = 5060
+      target = "bigbox.example.com."
+    }
+    ttl = 300
+  }`)
+
+var testAccDnsSRVRecordSet_update = fmt.Sprintf(`
+  resource "dns_srv_record_set" "foo" {
+    zone = "example.com."
+    name = "_sip._tcp"
+    srv {
+      priority = 10
+      weight = 60
+      port = 5060
+      target = "bigbox.example.com."
+    }
+    srv {
+      priority = 20
+      weight = 0
+      port = 5060
+      target = "backupbox.example.com."
+    }
+    ttl = 300
+  }`)

--- a/website/dns.erb
+++ b/website/dns.erb
@@ -32,6 +32,9 @@
                         <li<%= sidebar_current("docs-dns-datasource-ptr-record-set") %>>
                             <a href="/docs/providers/dns/d/dns_ptr_record_set.html">dns_ptr_record_set</a>
                         </li>
+                        <li<%= sidebar_current("docs-dns-datasource-srv-record-set") %>>
+                            <a href="/docs/providers/dns/d/dns_srv_record_set.html">dns_srv_record_set</a>
+                        </li>
                         <li<%= sidebar_current("docs-dns-datasource-txt-record-set") %>>
                             <a href="/docs/providers/dns/d/dns_txt_record_set.html">dns_txt_record_set</a>
                         </li>
@@ -58,6 +61,9 @@
                     </li>
                     <li<%= sidebar_current("docs-dns-ptr-record") %>>
           <a href="/docs/providers/dns/r/dns_ptr_record.html">dns_ptr_record</a>
+                    </li>
+                    <li<%= sidebar_current("docs-dns-srv-record-set") %>>
+          <a href="/docs/providers/dns/r/dns_srv_record_set.html">dns_srv_record_set</a>
                     </li>
                     <li<%= sidebar_current("docs-dns-txt-record-set") %>>
           <a href="/docs/providers/dns/r/dns_txt_record_set.html">dns_txt_record_set</a>

--- a/website/docs/d/dns_srv_record_set.html.markdown
+++ b/website/docs/d/dns_srv_record_set.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "dns"
+page_title: "DNS: dns_srv_record_set"
+sidebar_current: "docs-dns-datasource-srv-record-set"
+description: |-
+  Get DNS SRV record set.
+---
+
+# dns_srv_record_set
+
+Use this data source to get DNS SRV records for a service.
+
+## Example Usage
+
+```hcl
+data "dns_srv_record_set" "sip" {
+  service = "_sip._tcp.example.com."
+}
+
+output "sipserver" {
+  value = "${data.dns_srv_record_set.sip.srv.0.target}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+ * `service` - (Required): Service to look up
+
+## Attributes Reference
+
+The following attributes are exported:
+
+ * `id` - Set to `service`.
+ * `srv` - A list of records. They are sorted to stay consistent across runs.

--- a/website/docs/r/dns_srv_record_set.html.markdown
+++ b/website/docs/r/dns_srv_record_set.html.markdown
@@ -1,0 +1,72 @@
+---
+layout: "dns"
+page_title: "DNS: dns_srv_record_set"
+sidebar_current: "docs-dns-srv-record-set"
+description: |-
+  Creates an SRV type DNS record set.
+---
+
+# dns_srv_record_set
+
+Creates an SRV type DNS record set.
+
+## Example Usage
+
+```hcl
+resource "dns_srv_record_set" "sip" {
+  zone = "example.com."
+  name = "_sip._tcp"
+  srv {
+    priority = 10
+    weight   = 60
+    target   = "bigbox.example.com."
+    port     = 5060
+  }
+  srv {
+    priority = 10
+    weight   = 20
+    target   = "smallbox1.example.com."
+    port     = 5060
+  }
+  srv {
+    priority = 10
+    weight   = 20
+    target   = "smallbox2.example.com."
+    port     = 5060
+  }
+  ttl = 300
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone` - (Required) DNS zone the record set belongs to. It must be an FQDN, that is, include the trailing dot.
+* `name` - (Required) The name of the record set. The `zone` argument will be appended to this value to create the full record path.
+* `srv` - (Required) Can be specified multiple times for each SRV record. Each block supports fields documented below.
+* `ttl` - (Optional) The TTL of the record set. Defaults to `3600`.
+
+The `srv` block supports:
+
+* `priority` - (Required) The priority for the record.
+* `weight` - (Required) The weight for the record.
+* `target` - (Required) The FQDN of the target, include the trailing dot.
+* `port` - (Required) The port for the service on the target.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `zone` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `srv` - See Argument Reference above.
+* `ttl` - See Argument Reference above.
+
+## Import
+
+Records can be imported using the FQDN, e.g.
+
+```
+$ terraform import dns_srv_record_set.sip _sip._tcp.example.com.
+```


### PR DESCRIPTION
This builds on #69 and adds SRV record support.

Records can be created with the following:
```hcl
resource "dns_srv_record_set" "sip" {
  zone = "example.com."
  name = "_sip._tcp"
  ttl  = 86400

  srv {
    priority = 10
    weight   = 60
    target   = "sip.example.com."
    port     = 5060
  }
}
```
Records can be queried with:
```hcl
data "dns_srv_record_set" "kerberos" {
  service = "_kerberos._tcp.example.com."
}

output "kerberos" {
  value = "${data.dns_srv_record_set.kerberos.srv.0.target}"
}
```
The only problem I have with the data source is that I don't know of a reliable external SRV record I can query for tests, so they're currently commented out.

Fixes #45