### PR TITLE
MX record resource and datasource

### DIFF
--- a/dns/data_dns_mx_record_set.go
+++ b/dns/data_dns_mx_record_set.go
@@ -1,0 +1,72 @@
+package dns
+
+import (
+	"fmt"
+	"net"
+	"sort"
+
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func dataSourceDnsMXRecordSet() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceDnsMXRecordSetRead,
+		Schema: map[string]*schema.Schema{
+			"domain": &schema.Schema{
+				Type:     schema.TypeString,
+				Required: true,
+			},
+			"mx": &schema.Schema{
+				Type: schema.TypeList,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"preference": {
+							Type:     schema.TypeInt,
+							Computed: true,
+						},
+						"exchange": {
+							Type:     schema.TypeString,
+							Computed: true,
+						},
+					},
+				},
+				Computed: true,
+			},
+		},
+	}
+}
+
+func dataSourceDnsMXRecordSetRead(d *schema.ResourceData, meta interface{}) error {
+	domain := d.Get("domain").(string)
+
+	records, err := net.LookupMX(domain)
+	if err != nil {
+		return fmt.Errorf("error looking up MX records for %q: %s", domain, err)
+	}
+
+	// Sort by preference ascending, and host alphabetically
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].Pref < records[j].Pref {
+			return true
+		}
+		if records[i].Pref > records[j].Pref {
+			return false
+		}
+		return records[i].Host < records[j].Host
+	})
+
+	mx := make([]map[string]interface{}, len(records))
+	for i, record := range records {
+		mx[i] = map[string]interface{}{
+			"preference": int(record.Pref),
+			"exchange":   record.Host,
+		}
+	}
+
+	if err = d.Set("mx", mx); err != nil {
+		return err
+	}
+	d.SetId(domain)
+
+	return nil
+}

--- a/dns/data_dns_mx_record_set_test.go
+++ b/dns/data_dns_mx_record_set_test.go
@@ -1,0 +1,104 @@
+package dns
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+func TestAccDataDnsMXRecordSet_Basic(t *testing.T) {
+	tests := []struct {
+		DataSourceBlock string
+		DataSourceName  string
+		Expected        []map[string]string
+		Domain          string
+	}{
+		{
+			`
+			data "dns_mx_record_set" "mx" {
+			  domain = "google.com"
+			}
+			`,
+			"mx",
+			[]map[string]string{
+				{"preference": "10", "exchange": "aspmx.l.google.com."},
+				{"preference": "20", "exchange": "alt1.aspmx.l.google.com."},
+				{"preference": "30", "exchange": "alt2.aspmx.l.google.com."},
+				{"preference": "40", "exchange": "alt3.aspmx.l.google.com."},
+				{"preference": "50", "exchange": "alt4.aspmx.l.google.com."},
+			},
+			"google.com",
+		},
+	}
+
+	for _, test := range tests {
+		recordName := fmt.Sprintf("data.dns_mx_record_set.%s", test.DataSourceName)
+
+		resource.Test(t, resource.TestCase{
+			Providers: testAccProviders,
+			Steps: []resource.TestStep{
+				{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						testAccDataDnsMXExpected(recordName, "mx", test.Expected),
+					),
+				},
+				{
+					Config: test.DataSourceBlock,
+					Check: resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(recordName, "id", test.Domain),
+					),
+				},
+			},
+		})
+	}
+}
+
+func testAccDataDnsMXExpected(name, key string, value []map[string]string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		ms := s.RootModule()
+		rs, ok := ms.Resources[name]
+		if !ok {
+			return fmt.Errorf("Not found: %s", name)
+		}
+
+		is := rs.Primary
+		if is == nil {
+			return fmt.Errorf("No primary instance: %s", name)
+		}
+
+		attrKey := fmt.Sprintf("%s.#", key)
+		count, ok := is.Attributes[attrKey]
+		if !ok {
+			return fmt.Errorf("Attributes not found for %s", attrKey)
+		}
+
+		gotCount, _ := strconv.Atoi(count)
+		if gotCount != len(value) {
+			return fmt.Errorf("Mismatch array count for %s: got %s, wanted %d", key, count, len(value))
+		}
+
+		for i := 0; i < gotCount; i++ {
+			mx := make(map[string]string)
+
+			for _, attr := range []string{"exchange", "preference"} {
+				attrKey = fmt.Sprintf("%s.%d.%s", key, i, attr)
+				got, ok := is.Attributes[attrKey]
+				if !ok {
+					return fmt.Errorf("Missing attribute for %s", attrKey)
+				}
+				mx[attr] = got
+			}
+
+			if !reflect.DeepEqual(mx, value[i]) {
+				return fmt.Errorf("Expected %v, got %v", value[i], mx)
+			}
+		}
+
+		return nil
+	}
+}

--- a/dns/provider.go
+++ b/dns/provider.go
@@ -99,16 +99,18 @@ func Provider() terraform.ResourceProvider {
 			"dns_a_record_set":     dataSourceDnsARecordSet(),
 			"dns_aaaa_record_set":  dataSourceDnsAAAARecordSet(),
 			"dns_cname_record_set": dataSourceDnsCnameRecordSet(),
-			"dns_txt_record_set":   dataSourceDnsTxtRecordSet(),
+			"dns_mx_record_set":    dataSourceDnsMXRecordSet(),
 			"dns_ns_record_set":    dataSourceDnsNSRecordSet(),
 			"dns_ptr_record_set":   dataSourceDnsPtrRecordSet(),
+			"dns_txt_record_set":   dataSourceDnsTxtRecordSet(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
 			"dns_a_record_set":    resourceDnsARecordSet(),
-			"dns_ns_record_set":   resourceDnsNSRecordSet(),
 			"dns_aaaa_record_set": resourceDnsAAAARecordSet(),
 			"dns_cname_record":    resourceDnsCnameRecord(),
+			"dns_mx_record_set":   resourceDnsMXRecordSet(),
+			"dns_ns_record_set":   resourceDnsNSRecordSet(),
 			"dns_ptr_record":      resourceDnsPtrRecord(),
 		},
 

--- a/dns/resource_dns_mx_record_set.go
+++ b/dns/resource_dns_mx_record_set.go
@@ -1,0 +1,167 @@
+package dns
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/miekg/dns"
+)
+
+func resourceDnsMXRecordSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDnsMXRecordSetCreate,
+		Read:   resourceDnsMXRecordSetRead,
+		Update: resourceDnsMXRecordSetUpdate,
+		Delete: resourceDnsMXRecordSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDnsImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"zone": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateZone,
+			},
+			"name": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateName,
+			},
+			"mx": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"preference": {
+							Type:     schema.TypeInt,
+							Required: true,
+						},
+						"exchange": {
+							Type:         schema.TypeString,
+							Required:     true,
+							ValidateFunc: validateZone,
+						},
+					},
+				},
+				Set: resourceDnsMXRecordSetHash,
+			},
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  3600,
+			},
+		},
+	}
+}
+
+func resourceDnsMXRecordSetCreate(d *schema.ResourceData, meta interface{}) error {
+
+	d.SetId(resourceFQDN(d))
+
+	return resourceDnsMXRecordSetUpdate(d, meta)
+}
+
+func resourceDnsMXRecordSetRead(d *schema.ResourceData, meta interface{}) error {
+
+	answers, err := resourceDnsRead(d, meta, dns.TypeMX)
+	if err != nil {
+		return err
+	}
+
+	if len(answers) > 0 {
+
+		var ttl sort.IntSlice
+
+		mx := schema.NewSet(resourceDnsMXRecordSetHash, nil)
+		for _, record := range answers {
+			switch r := record.(type) {
+			case *dns.MX:
+				m := map[string]interface{}{
+					"preference": int(r.Preference),
+					"exchange":   r.Mx,
+				}
+				mx.Add(m)
+				ttl = append(ttl, int(r.Hdr.Ttl))
+			default:
+				return fmt.Errorf("didn't get an MX record")
+			}
+		}
+		sort.Sort(ttl)
+
+		d.Set("mx", mx)
+		d.Set("ttl", ttl[0])
+	} else {
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceDnsMXRecordSetUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	if meta != nil {
+
+		ttl := d.Get("ttl").(int)
+		fqdn := resourceFQDN(d)
+
+		msg := new(dns.Msg)
+
+		msg.SetUpdate(d.Get("zone").(string))
+
+		if d.HasChange("mx") {
+			o, n := d.GetChange("mx")
+			os := o.(*schema.Set)
+			ns := n.(*schema.Set)
+			remove := os.Difference(ns).List()
+			add := ns.Difference(os).List()
+
+			// Loop through all the old addresses and remove them
+			for _, mx := range remove {
+				m := mx.(map[string]interface{})
+				rr_remove, _ := dns.NewRR(fmt.Sprintf("%s %d MX %d %s", fqdn, ttl, m["preference"], m["exchange"]))
+				msg.Remove([]dns.RR{rr_remove})
+			}
+			// Loop through all the new addresses and insert them
+			for _, mx := range add {
+				m := mx.(map[string]interface{})
+				rr_insert, _ := dns.NewRR(fmt.Sprintf("%s %d MX %d %s", fqdn, ttl, m["preference"], m["exchange"]))
+				msg.Insert([]dns.RR{rr_insert})
+			}
+
+			r, err := exchange(msg, true, meta)
+			if err != nil {
+				d.SetId("")
+				return fmt.Errorf("Error updating DNS record: %s", err)
+			}
+			if r.Rcode != dns.RcodeSuccess {
+				d.SetId("")
+				return fmt.Errorf("Error updating DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
+			}
+		}
+
+		return resourceDnsMXRecordSetRead(d, meta)
+	} else {
+		return fmt.Errorf("update server is not set")
+	}
+}
+
+func resourceDnsMXRecordSetDelete(d *schema.ResourceData, meta interface{}) error {
+
+	return resourceDnsDelete(d, meta, dns.TypeMX)
+}
+
+func resourceDnsMXRecordSetHash(v interface{}) int {
+	var buf bytes.Buffer
+	m := v.(map[string]interface{})
+	buf.WriteString(fmt.Sprintf("%d-", m["preference"].(int)))
+	buf.WriteString(fmt.Sprintf("%s-", m["exchange"].(string)))
+
+	return hashcode.String(buf.String())
+}

--- a/dns/resource_dns_mx_record_set_test.go
+++ b/dns/resource_dns_mx_record_set_test.go
@@ -1,0 +1,174 @@
+package dns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/miekg/dns"
+)
+
+func TestAccDnsMXRecordSet_Basic(t *testing.T) {
+
+	var name, zone string
+	resourceName := "dns_mx_record_set.foo"
+	resourceRoot := "dns_mx_record_set.root"
+
+	deleteMXRecordSet := func() {
+		meta := testAccProvider.Meta()
+
+		msg := new(dns.Msg)
+
+		msg.SetUpdate(zone)
+
+		fqdn := testResourceFQDN(name, zone)
+
+		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 MX", fqdn))
+		msg.RemoveRRset([]dns.RR{rr_remove})
+
+		r, err := exchange(msg, true, meta)
+		if err != nil {
+			t.Fatalf("Error deleting DNS record: %s", err)
+		}
+		if r.Rcode != dns.RcodeSuccess {
+			t.Fatalf("Error deleting DNS record: %v", r.Rcode)
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDnsMXRecordSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsMXRecordSet_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mx.#", "1"),
+					testAccCheckDnsMXRecordSetExists(t, resourceName, []interface{}{map[string]interface{}{"preference": 10, "exchange": "smtp.example.org."}}, &name, &zone),
+				),
+			},
+			{
+				Config: testAccDnsMXRecordSet_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mx.#", "2"),
+					testAccCheckDnsMXRecordSetExists(t, resourceName, []interface{}{map[string]interface{}{"preference": 10, "exchange": "smtp.example.org."}, map[string]interface{}{"preference": 20, "exchange": "backup.example.org."}}, &name, &zone),
+				),
+			},
+			{
+				PreConfig: deleteMXRecordSet,
+				Config:    testAccDnsMXRecordSet_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "mx.#", "2"),
+					testAccCheckDnsMXRecordSetExists(t, resourceName, []interface{}{map[string]interface{}{"preference": 10, "exchange": "smtp.example.org."}, map[string]interface{}{"preference": 20, "exchange": "backup.example.org."}}, &name, &zone),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDnsMXRecordSet_root,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceRoot, "mx.#", "1"),
+					testAccCheckDnsMXRecordSetExists(t, resourceRoot, []interface{}{map[string]interface{}{"preference": 10, "exchange": "smtp.example.org."}}, &name, &zone),
+				),
+			},
+			{
+				ResourceName:      resourceRoot,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDnsMXRecordSetDestroy(s *terraform.State) error {
+	return testAccCheckDnsDestroy(s, "dns_mx_record_set", dns.TypeMX)
+}
+
+func testAccCheckDnsMXRecordSetExists(t *testing.T, n string, mx []interface{}, name, zone *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		*name = rs.Primary.Attributes["name"]
+		*zone = rs.Primary.Attributes["zone"]
+
+		fqdn := testResourceFQDN(*name, *zone)
+
+		meta := testAccProvider.Meta()
+
+		msg := new(dns.Msg)
+		msg.SetQuestion(fqdn, dns.TypeMX)
+		r, err := exchange(msg, false, meta)
+		if err != nil {
+			return fmt.Errorf("Error querying DNS record: %s", err)
+		}
+		if r.Rcode != dns.RcodeSuccess {
+			return fmt.Errorf("Error querying DNS record")
+		}
+
+		existing := schema.NewSet(resourceDnsMXRecordSetHash, nil)
+		expected := schema.NewSet(resourceDnsMXRecordSetHash, mx)
+		for _, record := range r.Answer {
+			switch r := record.(type) {
+			case *dns.MX:
+				m := map[string]interface{}{
+					"preference": int(r.Preference),
+					"exchange":   r.Mx,
+				}
+				existing.Add(m)
+			default:
+				return fmt.Errorf("didn't get an MX record")
+			}
+		}
+		if !existing.Equal(expected) {
+			return fmt.Errorf("DNS record differs: expected %v, found %v", expected, existing)
+		}
+		return nil
+	}
+}
+
+var testAccDnsMXRecordSet_basic = fmt.Sprintf(`
+  resource "dns_mx_record_set" "foo" {
+    zone = "example.com."
+    name = "foo"
+    mx {
+      preference = 10
+      exchange = "smtp.example.org."
+    }
+    ttl = 300
+  }`)
+
+var testAccDnsMXRecordSet_update = fmt.Sprintf(`
+  resource "dns_mx_record_set" "foo" {
+    zone = "example.com."
+    name = "foo"
+    mx {
+      preference = 10
+      exchange = "smtp.example.org."
+    }
+    mx {
+      preference = 20
+      exchange = "backup.example.org."
+    }
+    ttl = 300
+  }`)
+
+var testAccDnsMXRecordSet_root = fmt.Sprintf(`
+  resource "dns_mx_record_set" "root" {
+    zone = "example.com."
+    mx {
+      preference = 10
+      exchange = "smtp.example.org."
+    }
+    ttl = 300
+  }`)

--- a/website/dns.erb
+++ b/website/dns.erb
@@ -23,6 +23,9 @@
                         <li<%= sidebar_current("docs-dns-datasource-cname-record-set") %>>
                             <a href="/docs/providers/dns/d/dns_cname_record_set.html">dns_cname_record_set</a>
                         </li>
+                        <li<%= sidebar_current("docs-dns-datasource-mx-record-set") %>>
+                            <a href="/docs/providers/dns/d/dns_mx_record_set.html">dns_mx_record_set</a>
+                        </li>
                         <li<%= sidebar_current("docs-dns-datasource-ns-record-set") %>>
                             <a href="/docs/providers/dns/d/dns_ns_record_set.html">dns_ns_record_set</a>
                         </li>
@@ -46,6 +49,9 @@
                     </li>
                     <li<%= sidebar_current("docs-dns-cname-record") %>>
           <a href="/docs/providers/dns/r/dns_cname_record.html">dns_cname_record</a>
+                    </li>
+                    <li<%= sidebar_current("docs-dns-mx-record-set") %>>
+          <a href="/docs/providers/dns/r/dns_mx_record_set.html">dns_mx_record_set</a>
                     </li>
                     <li<%= sidebar_current("docs-dns-ns-record-set") %>>
           <a href="/docs/providers/dns/r/dns_ns_record_set.html">dns_ns_record_set</a>

--- a/website/docs/d/dns_mx_record_set.html.markdown
+++ b/website/docs/d/dns_mx_record_set.html.markdown
@@ -1,0 +1,36 @@
+---
+layout: "dns"
+page_title: "DNS: dns_mx_record_set"
+sidebar_current: "docs-dns-datasource-mx-record-set"
+description: |-
+  Get DNS MX record set.
+---
+
+# dns_mx_record_set
+
+Use this data source to get DNS MX records for a domain.
+
+## Example Usage
+
+```hcl
+data "dns_mx_record_set" "mail" {
+  domain = "example.com."
+}
+
+output "mailserver" {
+  value = "${data.dns_mx_record_set.mail.mx.0.exchange}"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+ * `domain` - (Required): Domain to look up
+
+## Attributes Reference
+
+The following attributes are exported:
+
+ * `id` - Set to `service`.
+ * `mx` - A list of records. They are sorted by ascending preference then alphabetically by exchange to stay consistent across runs.

--- a/website/docs/r/dns_mx_record_set.html.markdown
+++ b/website/docs/r/dns_mx_record_set.html.markdown
@@ -1,0 +1,86 @@
+---
+layout: "dns"
+page_title: "DNS: dns_mx_record_set"
+sidebar_current: "docs-dns-mx-record-set"
+description: |-
+  Creates an MX type DNS record set.
+---
+
+# dns_mx_record_set
+
+Creates an MX type DNS record set.
+
+## Example Usage
+
+```hcl
+resource "dns_a_record_set" "smtp" {
+  zone = "example.com."
+  name = "smtp"
+  ttl  = 300
+
+  addresses = [
+    "192.0.2.1",
+  ]
+}
+
+resource "dns_a_record_set" "backup" {
+  zone = "example.com."
+  name = "backup"
+  ttl  = 300
+
+  addresses = [
+    "192.0.2.2",
+  ]
+}
+
+resource "dns_mx_record_set" "mx" {
+  zone = "example.com."
+  ttl  = 300
+
+  mx {
+    preference = 10
+    exchange   = "smtp.example.com."
+  }
+
+  mx {
+    preference = 20
+    exchange   = "backup.example.com."
+  }
+
+  depends_on = [
+    "dns_a_record_set.smtp",
+    "dns_a_record_set.backup",
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone` - (Required) DNS zone the record set belongs to. It must be an FQDN, that is, include the trailing dot.
+* `name` - (Optional) The name of the record set. The `zone` argument will be appended to this value to create the full record path.
+* `mx` - (Required) Can be specified multiple times for each MX record. Each block supports fields documented below.
+* `ttl` - (Optional) The TTL of the record set. Defaults to `3600`.
+
+The `mx` block supports:
+
+* `preference` - (Required) The preference for the record.
+* `exchange` - (Required) The FQDN of the mail exchange, include the trailing dot.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `zone` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `mx` - See Argument Reference above.
+* `ttl` - See Argument Reference above.
+
+## Import
+
+Records can be imported using the FQDN, e.g.
+
+```shell
+$ terraform import dns_mx_record_set.mx example.com.
+```


### PR DESCRIPTION
The builds on #69 and adds MX record support.

Records can be created with the following:
```hcl
resource "dns_mx_record_set" "mx" {
  zone = "example.com."
  ttl  = 86400

  mx {
    preference = 10
    exchange   = "smtp.example.com."
  }

  depends_on = [
    "dns_a_record_set.smtp",
    "dns_aaaa_record_set.smtp",
  ]
}
```
**EDIT:** I've found that if you try and set the MX pointing to a record that doesn't exist in the zone, BIND will refuse to add it so you need to create an A or AAAA record set and add `depends_on = [ ... ]` to the MX record resource to ensure they're created first. I've updated the documentation with an example of this.

Records can be queried with:
```hcl
data "dns_mx_record_set" "mail" {
  domain = "example.com."
}

output "mail" {
  value = "${data.dns_mx_record_set.mail.mx.0.exchange}"
}
```
Fixes #51 