### PR TITLE
TXT record resource

### DIFF
--- a/dns/provider.go
+++ b/dns/provider.go
@@ -110,6 +110,7 @@ func Provider() terraform.ResourceProvider {
 			"dns_aaaa_record_set": resourceDnsAAAARecordSet(),
 			"dns_cname_record":    resourceDnsCnameRecord(),
 			"dns_ptr_record":      resourceDnsPtrRecord(),
+			"dns_txt_record_set":  resourceDnsTXTRecordSet(),
 		},
 
 		ConfigureFunc: configureProvider,

--- a/dns/resource_dns_txt_record_set.go
+++ b/dns/resource_dns_txt_record_set.go
@@ -1,0 +1,139 @@
+package dns
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/miekg/dns"
+)
+
+func resourceDnsTXTRecordSet() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceDnsTXTRecordSetCreate,
+		Read:   resourceDnsTXTRecordSetRead,
+		Update: resourceDnsTXTRecordSetUpdate,
+		Delete: resourceDnsTXTRecordSetDelete,
+		Importer: &schema.ResourceImporter{
+			State: resourceDnsImport,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"zone": &schema.Schema{
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validateZone,
+			},
+			"name": &schema.Schema{
+				Type:         schema.TypeString,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validateName,
+			},
+			"txt": &schema.Schema{
+				Type:     schema.TypeSet,
+				Required: true,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+			},
+			"ttl": &schema.Schema{
+				Type:     schema.TypeInt,
+				Optional: true,
+				ForceNew: true,
+				Default:  3600,
+			},
+		},
+	}
+}
+
+func resourceDnsTXTRecordSetCreate(d *schema.ResourceData, meta interface{}) error {
+
+	d.SetId(resourceFQDN(d))
+
+	return resourceDnsTXTRecordSetUpdate(d, meta)
+}
+
+func resourceDnsTXTRecordSetRead(d *schema.ResourceData, meta interface{}) error {
+
+	answers, err := resourceDnsRead(d, meta, dns.TypeTXT)
+	if err != nil {
+		return err
+	}
+
+	if len(answers) > 0 {
+
+		var ttl sort.IntSlice
+
+		txt := schema.NewSet(schema.HashString, nil)
+		for _, record := range answers {
+			switch r := record.(type) {
+			case *dns.TXT:
+				txt.Add(strings.Join(r.Txt, ""))
+				ttl = append(ttl, int(r.Hdr.Ttl))
+			default:
+				return fmt.Errorf("didn't get an TXT record")
+			}
+		}
+		sort.Sort(ttl)
+
+		d.Set("txt", txt)
+		d.Set("ttl", ttl[0])
+	} else {
+		d.SetId("")
+	}
+
+	return nil
+}
+
+func resourceDnsTXTRecordSetUpdate(d *schema.ResourceData, meta interface{}) error {
+
+	if meta != nil {
+
+		ttl := d.Get("ttl").(int)
+		fqdn := resourceFQDN(d)
+
+		msg := new(dns.Msg)
+
+		msg.SetUpdate(d.Get("zone").(string))
+
+		if d.HasChange("txt") {
+			o, n := d.GetChange("txt")
+			os := o.(*schema.Set)
+			ns := n.(*schema.Set)
+			remove := os.Difference(ns).List()
+			add := ns.Difference(os).List()
+
+			// Loop through all the old addresses and remove them
+			for _, txt := range remove {
+				rr_remove, _ := dns.NewRR(fmt.Sprintf("%s %d TXT \"%s\"", fqdn, ttl, txt))
+				msg.Remove([]dns.RR{rr_remove})
+			}
+			// Loop through all the new addresses and insert them
+			for _, txt := range add {
+				rr_insert, _ := dns.NewRR(fmt.Sprintf("%s %d TXT \"%s\"", fqdn, ttl, txt))
+				msg.Insert([]dns.RR{rr_insert})
+			}
+
+			r, err := exchange(msg, true, meta)
+			if err != nil {
+				d.SetId("")
+				return fmt.Errorf("Error updating DNS record: %s", err)
+			}
+			if r.Rcode != dns.RcodeSuccess {
+				d.SetId("")
+				return fmt.Errorf("Error updating DNS record: %v (%s)", r.Rcode, dns.RcodeToString[r.Rcode])
+			}
+		}
+
+		return resourceDnsTXTRecordSetRead(d, meta)
+	} else {
+		return fmt.Errorf("update server is not set")
+	}
+}
+
+func resourceDnsTXTRecordSetDelete(d *schema.ResourceData, meta interface{}) error {
+
+	return resourceDnsDelete(d, meta, dns.TypeTXT)
+}

--- a/dns/resource_dns_txt_record_set_test.go
+++ b/dns/resource_dns_txt_record_set_test.go
@@ -1,0 +1,158 @@
+package dns
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/helper/schema"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/miekg/dns"
+)
+
+func TestAccDnsTXTRecordSet_Basic(t *testing.T) {
+
+	var name, zone string
+	resourceName := "dns_txt_record_set.foo"
+	resourceRoot := "dns_txt_record_set.root"
+
+	deleteTXTRecordSet := func() {
+		meta := testAccProvider.Meta()
+
+		msg := new(dns.Msg)
+
+		msg.SetUpdate(zone)
+
+		fqdn := testResourceFQDN(name, zone)
+
+		rr_remove, _ := dns.NewRR(fmt.Sprintf("%s 0 TXT", fqdn))
+		msg.RemoveRRset([]dns.RR{rr_remove})
+
+		r, err := exchange(msg, true, meta)
+		if err != nil {
+			t.Fatalf("Error deleting DNS record: %s", err)
+		}
+		if r.Rcode != dns.RcodeSuccess {
+			t.Fatalf("Error deleting DNS record: %v", r.Rcode)
+		}
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckDnsARecordSetDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDnsTXTRecordSet_basic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "txt.#", "2"),
+					testAccCheckDnsTXTRecordSetExists(t, resourceName, []interface{}{"foo", "bar"}, &name, &zone),
+				),
+			},
+			{
+				Config: testAccDnsTXTRecordSet_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "txt.#", "3"),
+					testAccCheckDnsTXTRecordSetExists(t, resourceName, []interface{}{"foo", "bar", "baz"}, &name, &zone),
+				),
+			},
+			{
+				PreConfig: deleteTXTRecordSet,
+				Config:    testAccDnsTXTRecordSet_update,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "txt.#", "3"),
+					testAccCheckDnsTXTRecordSetExists(t, resourceName, []interface{}{"foo", "bar", "baz"}, &name, &zone),
+				),
+			},
+			{
+				ResourceName:      resourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+			{
+				Config: testAccDnsTXTRecordSet_root,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceRoot, "txt.#", "1"),
+					testAccCheckDnsTXTRecordSetExists(t, resourceRoot, []interface{}{"foo"}, &name, &zone),
+				),
+			},
+			{
+				ResourceName:      resourceRoot,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccCheckDnsTXTRecordSetDestroy(s *terraform.State) error {
+	return testAccCheckDnsDestroy(s, "dns_txt_record_set", dns.TypeTXT)
+}
+
+func testAccCheckDnsTXTRecordSetExists(t *testing.T, n string, txt []interface{}, name, zone *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set")
+		}
+
+		*name = rs.Primary.Attributes["name"]
+		*zone = rs.Primary.Attributes["zone"]
+
+		fqdn := testResourceFQDN(*name, *zone)
+
+		meta := testAccProvider.Meta()
+
+		msg := new(dns.Msg)
+		msg.SetQuestion(fqdn, dns.TypeTXT)
+		r, err := exchange(msg, false, meta)
+		if err != nil {
+			return fmt.Errorf("Error querying DNS record: %s", err)
+		}
+		if r.Rcode != dns.RcodeSuccess {
+			return fmt.Errorf("Error querying DNS record")
+		}
+
+		existing := schema.NewSet(schema.HashString, nil)
+		expected := schema.NewSet(schema.HashString, txt)
+		for _, record := range r.Answer {
+			switch r := record.(type) {
+			case *dns.TXT:
+				existing.Add(strings.Join(r.Txt, ""))
+			default:
+				return fmt.Errorf("didn't get an TXT record")
+			}
+		}
+		if !existing.Equal(expected) {
+			return fmt.Errorf("DNS record differs: expected %v, found %v", expected, existing)
+		}
+		return nil
+	}
+}
+
+var testAccDnsTXTRecordSet_basic = fmt.Sprintf(`
+  resource "dns_txt_record_set" "foo" {
+    zone = "example.com."
+    name = "foo"
+    txt = ["foo", "bar"]
+    ttl = 300
+  }`)
+
+var testAccDnsTXTRecordSet_update = fmt.Sprintf(`
+  resource "dns_txt_record_set" "foo" {
+    zone = "example.com."
+    name = "foo"
+    txt = ["foo", "bar", "baz"]
+    ttl = 300
+  }`)
+
+var testAccDnsTXTRecordSet_root = fmt.Sprintf(`
+  resource "dns_txt_record_set" "root" {
+    zone = "example.com."
+    txt = ["foo"]
+    ttl = 300
+  }`)

--- a/website/dns.erb
+++ b/website/dns.erb
@@ -53,6 +53,9 @@
                     <li<%= sidebar_current("docs-dns-ptr-record") %>>
           <a href="/docs/providers/dns/r/dns_ptr_record.html">dns_ptr_record</a>
                     </li>
+                    <li<%= sidebar_current("docs-dns-txt-record-set") %>>
+          <a href="/docs/providers/dns/r/dns_txt_record_set.html">dns_txt_record_set</a>
+                    </li>
                 </ul>
         </li>
       </ul>

--- a/website/docs/r/dns_txt_record_set.html.markdown
+++ b/website/docs/r/dns_txt_record_set.html.markdown
@@ -1,0 +1,49 @@
+---
+layout: "dns"
+page_title: "DNS: dns_txt_record_set"
+sidebar_current: "docs-dns-txt-record-set"
+description: |-
+  Creates a TXT type DNS record set.
+---
+
+# dns_txt_record_set
+
+Creates a TXT type DNS record set.
+
+## Example Usage
+
+```hcl
+resource "dns_txt_record_set" "google" {
+  zone = "example.com."
+  txt = [
+    "google-site-verification=...",
+  ]
+  ttl = 300
+}
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `zone` - (Required) DNS zone the record set belongs to. It must be an FQDN, that is, include the trailing dot.
+* `name` - (Optional) The name of the record set. The `zone` argument will be appended to this value to create the full record path.
+* `txt` - (Required) The text records this record set will be set to.
+* `ttl` - (Optional) The TTL of the record set. Defaults to `3600`.
+
+## Attributes Reference
+
+The following attributes are exported:
+
+* `zone` - See Argument Reference above.
+* `name` - See Argument Reference above.
+* `txt` - See Argument Reference above.
+* `ttl` - See Argument Reference above.
+
+## Import
+
+Records can be imported using the FQDN, e.g.
+
+```
+$ terraform import dns_txt_record_set.google example.com.
+```


### PR DESCRIPTION
This builds on #69 and adds TXT record resource support, a datasource already exists. This restores parity to the resource and datasource types available.

Records can be created with the following:
```hcl
resource "dns_txt_record_set" "google" {
  zone = "example.com."
  ttl  = 86400

  txt = [
    "google-site-verification=...",
  ]
}
```
The only limitation is that a TXT record can technically be comprised of multiple strings and I just concatenate them together into one, however the precedent here is that the golang `net.LookupTXT()` function loses this detail as well. If you create the records with Terraform then you'll be fine.