### PR TITLE
fix two issues with data_dns_txt_record_set_test.go

### DIFF
--- a/dns/data_dns_txt_record_set_test.go
+++ b/dns/data_dns_txt_record_set_test.go
@@ -23,6 +23,7 @@ func TestAccDataDnsTxtRecordSet_Basic(t *testing.T) {
 			"foo",
 			[]string{
 				"google-site-verification=LQZvxDzrGE-ZLudDpkpj-gcXN-5yF7Z6C-4Rljs3I_Q",
+				"google-site-verification=8d7FpfB8aOEYAIkoaVKxg7Ibj438CEypjZTH424Pews",
 			},
 			"terraform.io",
 		},
@@ -30,7 +31,7 @@ func TestAccDataDnsTxtRecordSet_Basic(t *testing.T) {
 
 	for _, test := range tests {
 		recordName := fmt.Sprintf("data.dns_txt_record_set.%s", test.DataSourceName)
-		resource.UnitTest(t, resource.TestCase{
+		resource.Test(t, resource.TestCase{
 			Providers: testAccProviders,
 			Steps: []resource.TestStep{
 				{


### PR DESCRIPTION
- the test was running as unit when it should have been acceptance only
- teraform.io now has 2 TXT records

Maybe this should be re-done using the local Bind in docker and not use
external domains